### PR TITLE
Fix missing square brackets

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -317,7 +317,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
   def floating_title node
     tag_name = %(h#{node.level + 1})
     id_attribute = node.id ? %( id="#{node.id}") : nil
-    %(<#{tag_name}#{id_attribute} class="#{'discrete', node.role].compact * ' '}">#{node.title}</#{tag_name}>)
+    %(<#{tag_name}#{id_attribute} class="#{['discrete', node.role].compact * ' '}">#{node.title}</#{tag_name}>)
   end
 
   def listing node


### PR DESCRIPTION
Fix error:

```
asciidoctor-epub3/lib/asciidoctor-epub3/converter.rb:320: syntax error, unexpected ']', expecting tSTRING_DEND
...class="#{'discrete', node.role].compact * ' '}">#{node.title...
```