### PR TITLE
Fix epub2 toc untitled

### DIFF
--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -16,7 +16,7 @@ module GepubBuilderMixin
   InlineImageMacroRx = /^image:(.*?)\[(.*?)\]$/
 
   def sanitized_doctitle doc, target = :plain
-    return (doc.attr 'untitled-label') unless doc.header?
+    return (doc.attr 'untitled-label') if doc.doctitle.nil?
     title = case target
     when :attribute_cdata
       doc.doctitle(sanitize: true).gsub('"', '&quot;')


### PR DESCRIPTION
`sanitized_doctitle` return `Untitled`  when `doc.header?` return false, but section node always return false.

Use `doctitle.nil?` instead.
