### PR TITLE
Fixed file type of avatar image in docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -255,7 +255,7 @@ The authors in each chapter document are aggregated together with the authors in
 
 |username
 |Used to resolve an avatar for the author that is displayed in the header of a chapter.
-The avatar image should be located at the path _$${imagesdir}/avatars/{username}.png$$_, where
+The avatar image should be located at the path _$${imagesdir}/avatars/{username}.jpg$$_, where
 `{username}` is the value of this attribute.
 
 |producer


### PR DESCRIPTION
The docs describe that the avatar image should be called `{username}.png` but actually only `{username}.jpg` seems to be supported. 

See:

https://github.com/asciidoctor/asciidoctor-epub3/blob/c9851d08aeee9b5b94fa9452fdb0763fcfc1ec25/lib/asciidoctor-epub3/converter.rb#L187

https://github.com/asciidoctor/asciidoctor-epub3/blob/c9851d08aeee9b5b94fa9452fdb0763fcfc1ec25/lib/asciidoctor-epub3/packager.rb#L189