### PR TITLE
Fix how publisher fonts are handled in KF8 format

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -596,7 +596,7 @@ We've covered all the scenarios!
 Hey WebKit, you've been Unicode punked!
 
 *UPDATE:* The zero-width no-break space was deprecated in favor of the word joiner.
-However, as we've discovered, font support for the word joiner is absymal, whereas the zero-width no-break space is supported everywhere we've checked.
+However, as we've discovered, font support for the word joiner is abysmal, whereas the zero-width no-break space is supported everywhere we've checked.
 Therefore, we've decided to go with the zero-width no-break space to avoid nasty rectangle outlines from font bombing your content.
 
 _By adding the +++<del>word joiner</del>+++ zero-width no-break space character immediately after any inline element, we can trick WebKit into justifying the text properly, as shown in the second screenshot above._

--- a/data/samples/sample-content.adoc
+++ b/data/samples/sample-content.adoc
@@ -133,7 +133,7 @@ Quotes, prose excerpts and verses share the same syntax structure, including:
 
 * style attribute, either `quote` or `verse`
 * name of who the content is attributed to
-* biblographical information of the book, speech, play, etc., where the content was drawn from
+* bibliographical information of the book, speech, play, etc., where the content was drawn from
 * excerpt text
 
 .Anatomy of a basic quote

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -149,7 +149,6 @@ class ContentConverter
     content = node.content
 
     # NOTE must run after content is resolved
-    # NOTE pubtree requires icon CSS to be repeated inside <body> (or in a linked stylesheet); wrap in div to hide from Aldiko
     # TODO perhaps create dynamic CSS file?
     if @icon_names.empty?
       icon_css_head = icon_css_scoped = nil
@@ -161,7 +160,8 @@ class ContentConverter
 #{icon_defs}
 </style>
 )
-      icon_css_scoped = %(<div style="display: none" aria-hidden="true"><style scoped="scoped">
+      # NOTE Namo Pubtree requires icon CSS to be repeated inside <body> (or in a linked stylesheet); wrap in div to hide from Aldiko
+      icon_css_scoped = (node.attr? 'ebook-format', 'kf8') ? nil : %(<div style="display: none" aria-hidden="true"><style scoped="scoped">
 #{icon_defs}
 </style></div>
 )

--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -60,13 +60,13 @@ module GepubBuilderMixin
       file 'styles/epub3-fonts.css' => font_css
       unless font_files.empty?
         # NOTE metadata property in oepbs package manifest doesn't work; must use proprietary iBooks file instead
-        #(@book.metadata.add_metadata 'meta', 'true')['property'] = 'ibooks:specified-fonts'
+        #(@book.metadata.add_metadata 'meta', 'true')['property'] = 'ibooks:specified-fonts' unless format == :kf8
         builder.optional_file 'META-INF/com.apple.ibooks.display-options.xml' => '<?xml version="1.0" encoding="UTF-8"?>
 <display_options>
 <platform name="*">
 <option name="specified-fonts">true</option>
 </platform>
-</display_options>'.to_ios
+</display_options>'.to_ios unless format == :kf8
 
         with_media_type 'application/x-font-ttf' do
           font_files.each do |font_file|
@@ -457,6 +457,7 @@ class Packager
     end
 
     if fmt == :kf8
+      # QUESTION shouldn't we validate this epub file too?
       distill_epub_to_mobi epub_file, target
     elsif options[:validate]
       validate_epub epub_file

--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -49,13 +49,19 @@ module GepubBuilderMixin
 
     # TODO improve design/UX of custom theme functionality, including custom fonts
     resources do
-      file 'styles/epub3.css' => (builder.postprocess_css_file ::File.join(workdir, 'epub3.css'), format)
-      file 'styles/epub3-css3-only.css' => (builder.postprocess_css_file ::File.join(workdir, 'epub3-css3-only.css'), format)
+      if format == :kf8
+        # NOTE add layer of indirection so Kindle Direct Publishing (KDP) doesn't strip font-related CSS rules
+        file 'styles/epub3.css' => '@import url("epub3-proxied.css");'.to_ios
+        file 'styles/epub3-css3-only.css' => '@import url("epub3-css3-only-proxied.css");'.to_ios
+        file 'styles/epub3-proxied.css' => (builder.postprocess_css_file ::File.join(workdir, 'epub3.css'), format)
+        file 'styles/epub3-css3-only-proxied.css' => (builder.postprocess_css_file ::File.join(workdir, 'epub3-css3-only.css'), format)
+      else
+        file 'styles/epub3.css' => (builder.postprocess_css_file ::File.join(workdir, 'epub3.css'), format)
+        file 'styles/epub3-css3-only.css' => (builder.postprocess_css_file ::File.join(workdir, 'epub3-css3-only.css'), format)
+      end
     end
 
     resources do
-      #file 'styles/epub3.css' => (builder.postprocess_css_file 'styles/epub3.css', format)
-      #file 'styles/epub3-css3-only.css' => (builder.postprocess_css_file 'styles/epub3-css3-only.css', format)
       font_files, font_css = builder.select_fonts ::File.join(DATA_DIR, 'styles/epub3-fonts.css'), (doc.attr 'scripts', 'latin')
       file 'styles/epub3-fonts.css' => font_css
       unless font_files.empty?


### PR DESCRIPTION
- proxy CSS in KF8 format to work around KDP removing font-related CSS
- don't include iBooks config file in KF8 format
- don't include scoped icon CSS in KF8 format