### PR TITLE
Changed the generation of doc titles in toc

### DIFF
--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -16,7 +16,8 @@ module GepubBuilderMixin
   InlineImageMacroRx = /^image:(.*?)\[(.*?)\]$/
 
   def sanitized_doctitle doc, target = :plain
-    return (doc.attr 'untitled-label') unless doc.header?
+    # NOTE checking only for doc.header? resulted in a toc.ncx with 'Untitled' chapters
+    return (doc.attr 'untitled-label') unless (doc.header? || doc.context == :document)
     title = case target
     when :attribute_cdata
       doc.doctitle(sanitize: true).gsub('"', '&quot;')


### PR DESCRIPTION
Before the toc.ncx (EPUB2) contained only 'Untitled' as chapter titles.
The method Builder#sanitized_doctitle looked only for the #header
property, and returned 'Untitled' unless this wasn't there. Now
 we look for #header or context == :document. This ensures that
 chapter titles are recognized.