### PR TITLE
register chapter ID in references

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -708,7 +708,7 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
           xdoc_id, xdoc_refid = refid.split '#', 2
           xdoc = node.document.references[:spine_items].find {|doc| xdoc_id == (doc.id || (doc.attr 'docname')) }
           if xdoc
-            unless (text = (xdoc_id == xdoc_refid ? xdoc.doctitle : xdoc.references[:ids][xdoc_refid]))
+            unless (text = xdoc.references[:ids][xdoc_refid])
               warn %(asciidoctor: WARNING: cannot resolve reference to #{xdoc_refid} in document #{xdoc_id})
               text = %([#{refid}])
             end

--- a/lib/asciidoctor-epub3/spine_item_processor.rb
+++ b/lib/asciidoctor-epub3/spine_item_processor.rb
@@ -53,7 +53,12 @@ class SpineItemProcessor < Extensions::IncludeProcessor
     # restore attributes to those defined in the document header
     spine_item_doc.restore_attributes
 
-    spine_item_doc.references[:spine_items] = ((spine_doc.references[:spine_items] ||= []) << spine_item_doc)
+    # FIXME core should register document ID if specified
+    unless (refs = spine_item_doc.references)[:ids].include? spine_item_doc.id
+      spine_item_doc.register :ids, [spine_item_doc.id, (spine_item_doc.attr 'docreftext') || spine_item_doc.doctitle]
+    end
+
+    refs[:spine_items] = ((spine_doc.references[:spine_items] ||= []) << spine_item_doc)
     # NOTE if there are attribute assignments between the include directives,
     # then this ordered list is not continguous, so bailing on the idea
     #reader.replace_line %(. link:#{::File.basename(spine_item_doc.attr 'outfile')}[#{spine_item_doc.doctitle}])


### PR DESCRIPTION
- register ID of each spine item document
- allow reftext for spine item doctitle to be specified using docreftext attribute