### PR TITLE
resolves #2 built-in avatar location should respect imagesdir

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -124,10 +124,8 @@ class ContentConverter
     else
       author = node.attr 'author'
       username = node.attr 'username', 'default'
-      # FIXME needs to resolve to the imagesdir of the spine document, not this document
-      #imagesdir = (node.attr 'imagesdir', '.').chomp '/'
-      #imagesdir = (imagesdir == '.' ? nil : %(#{imagesdir}/))
-      imagesdir = 'images/'
+      imagesdir = (node.references[:spine].attr 'imagesdir', '.').chomp '/'
+      imagesdir = (imagesdir == '.' ? nil : %(#{imagesdir}/))
       byline = %(<p class="byline"><img src="#{imagesdir}avatars/#{username}.jpg"/> <b class="author">#{author}</b></p>#{EOL})
     end
 

--- a/lib/asciidoctor-epub3/spine_item_processor.rb
+++ b/lib/asciidoctor-epub3/spine_item_processor.rb
@@ -60,6 +60,7 @@ class SpineItemProcessor < Extensions::IncludeProcessor
       spine_item_doc.register :ids, [spine_item_doc.id, (spine_item_doc.attr 'docreftext') || spine_item_doc.doctitle]
     end
 
+    refs[:spine] = spine_doc
     refs[:spine_items] = ((spine_doc.references[:spine_items] ||= []) << spine_item_doc)
     # NOTE if there are attribute assignments between the include directives,
     # then this ordered list is not continguous, so bailing on the idea


### PR DESCRIPTION
- use imagesdir from spine document for avatar location