### PR TITLE
Remove nil values for authors of spine documents

### DIFF
--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -480,7 +480,7 @@ class Packager
         .uniq {|img| %(#{(img.document.attr 'imagesdir', '.').chomp '/'}/#{img.attr 'target'}) }
     # FIXME authors should be aggregated already on parent document
     authors = if doc.attr? 'authors'
-      (doc.attr 'authors').split(GepubBuilderMixin::CsvDelimiterRx).concat(spine.map {|item| item.attr 'author' }).uniq
+      (doc.attr 'authors').split(GepubBuilderMixin::CsvDelimiterRx).concat(spine.map {|item| item.attr 'author' }).uniq.reject {|a| a.nil?}
     else
       []
     end


### PR DESCRIPTION
Spine documents without author information added nil values to the author
array, which led to empty contributor fields in content.opf.