### PR TITLE
leave it to the css to uppercase the titles

### DIFF
--- a/data/styles/epub3.css
+++ b/data/styles/epub3.css
@@ -568,7 +568,7 @@ h5 {
 
   font-size: 0.9em;
   font-weight: 700;
-  text-transform: uppercase;
+  text-transform: uppercase; /* not supported in Adobe Digital Editions */
   margin-top: 1.11em; /* 1rem */
   margin-bottom: -0.972em; /* -0.875rem */
 }
@@ -600,7 +600,7 @@ h1.chapter-title {
   margin-bottom: 0;
   padding-bottom: 0.8333em; /* 1.2rem */
   color: #B3B3B1;
-  text-transform: uppercase;
+  text-transform: uppercase; /* not supported in Adobe Digital Editions */
   word-spacing: -0.075em;
   letter-spacing: -0.01em;
   border-bottom: 1px solid #DCDCDE;
@@ -794,7 +794,7 @@ aside.sidebar.titled {
 }
 
 aside.sidebar > h2 {
-  /*text-transform: uppercase;*/ /* uppercase done manually to support Aldiko */
+  text-transform: uppercase; /* not supported in Adobe Digital Editions */
   font-size: 1em;
   /*
   font-weight: 700;

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -58,8 +58,6 @@ class ContentConverter
 
   XmlElementRx = /<\/?.+?>/
   CharEntityRx = /&#(\d{2,6});/
-  NamedEntityRx = /&([A-Z]+);/
-  UppercaseTagRx = /<(\/)?([A-Z]+)>/
 
   FromHtmlSpecialCharsMap = {
     '&lt;' => '<',
@@ -102,20 +100,15 @@ class ContentConverter
 
     if (doctitle = node.doctitle partition: true, sanitize: true, use_fallback: true).subtitle?
       title = doctitle.main
-      title_upper = title.upcase
       subtitle = doctitle.subtitle
     else
       # HACK until we get proper handling of title-only in CSS
-      title = title_upper = ''
+      title = ''
       subtitle = doctitle.combined
     end
 
     doctitle_sanitized = doctitle.combined
     subtitle_formatted = subtitle.split.map {|w| %(<b>#{w}</b>) } * ' '
-    # FIXME use uppercase pcdata helper to make less fragile (see logic in Asciidoctor PDF)
-    subtitle_formatted_upper = subtitle_formatted.upcase
-        .gsub(UppercaseTagRx) { %(<#{$1}#{$2.downcase}>) }
-        .gsub(NamedEntityRx) { %(&#{$1.downcase};) }
 
     if (node.attr 'publication-type', 'book') == 'book'
       byline = nil
@@ -171,7 +164,7 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
 <section class="chapter" title="#{doctitle_sanitized.gsub '"', '&quot;'}" epub:type="chapter" id="#{docid}">
 #{icon_css_scoped}<header>
 <div class="chapter-header">
-#{byline}<h1 class="chapter-title">#{title_upper}#{subtitle ? %[ <small class="subtitle">#{subtitle_formatted_upper}</small>] : nil}</h1>
+#{byline}<h1 class="chapter-title">#{title}#{subtitle ? %[ <small class="subtitle">#{subtitle_formatted}</small>] : nil}</h1>
 </div>
 </header>
 #{content})]
@@ -401,9 +394,7 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
       title = node.title
       title_sanitized = xml_sanitize title
       title_attr = %( title="#{title_sanitized}")
-      # FIXME use uppercase pcdata helper to make less fragile (see logic in Asciidoctor PDF)
-      title_upper = title.upcase.gsub(NamedEntityRx) { %(&#{$1.downcase};) }
-      title_el = %(<h2>#{title_upper}</h2>
+      title_el = %(<h2>#{title}</h2>
 )
     else
       title_attr = nil


### PR DESCRIPTION
This uses the chapter title text as the user had it, and leaves it to the CSS to uppercase.

The current stylesheet already has `text-transform: uppercase` on the titles.

This was noted at #97. I am also trying to use a custom CSS for the chapter header that doesn't have uppercased titles.

