### PR TITLE
chapter title logic

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -102,9 +102,8 @@ class ContentConverter
       title = doctitle.main
       subtitle = doctitle.subtitle
     else
-      # HACK until we get proper handling of title-only in CSS
-      title = ''
-      subtitle = doctitle.combined
+      title = doctitle.combined
+      subtitle = nil
     end
 
     doctitle_sanitized = doctitle.combined


### PR DESCRIPTION
This applies the logic to use the chapter's title in the `<h1 class="chapter-title">` instead of its subtitle.

I think it is actually uncommon for an ebook to display the book's title in every chapter, and the chapter title below. Aesthetically it is over the top as well. It is an impressive demonstration in the sample ebook, but the other case (only chapter title) should work well by default as well.