### PR TITLE
resolves #5 package inline images

### DIFF
--- a/data/styles/epub3.css
+++ b/data/styles/epub3.css
@@ -730,15 +730,8 @@ figure.image {
 }
 
 figure.image img {
-  /* in the event the viewer adds display: block to the image */
-  /*max-width: 95%;*/
-  /* max-width not supported in Kindle, need to use a media query to add */
+  display: block;
   margin: 0 auto;
-}
-
-/* Kindle requires text-align: center on surrounding div to align image to center */
-figure.image div.content {
-  text-align: center;
 }
 
 figure.coalesce {

--- a/data/styles/epub3.css
+++ b/data/styles/epub3.css
@@ -138,6 +138,7 @@ kbd {
 
 img {
   border: 0;
+  max-width: 100%;
 }
 
 mark {
@@ -729,7 +730,15 @@ figure.image {
 }
 
 figure.image img {
-  max-width: 100%;
+  /* in the event the viewer adds display: block to the image */
+  /*max-width: 95%;*/
+  /* max-width not supported in Kindle, need to use a media query to add */
+  margin: 0 auto;
+}
+
+/* Kindle requires text-align: center on surrounding div to align image to center */
+figure.image div.content {
+  text-align: center;
 }
 
 figure.coalesce {
@@ -898,18 +907,6 @@ blockquote footer .context {
   font-size: 0.9em;
   letter-spacing: -0.05em;
   color: #666665;
-}
-
-/* Kindle requires text-align: center on surrounding div to align image to center */
-figure.image div.content {
-  text-align: center;
-}
-
-/* in the event the viewer adds display: block to the image */
-figure.image img {
-  /* max-width not supported in Kindle, need to use a media query to add */
-  /*max-width: 95%;*/
-  margin: 0 auto;
 }
 
 pre {

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -632,11 +632,8 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
     when 'svg'
       img_attrs << %(style="width: #{node.attr 'scaledwidth', '100%'}")
       # TODO make this a convenience method on document
-      epub_properties = (node.document.attr 'epub-properties') || []
-      unless epub_properties.include? 'svg'
-        epub_properties << 'svg'
-        node.document.attributes['epub-properties'] = epub_properties
-      end
+      epub_properties = (node.document.attributes['epub-properties'] ||= [])
+      epub_properties << 'svg' unless epub_properties.include? 'svg'
     else
       if node.attr? 'scaledwidth'
         img_attrs << %(style="width: #{node.attr 'scaledwidth'}")
@@ -770,8 +767,16 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
       %(<i class="#{i_classes * ' '}"></i>)
     else
       target = node.image_uri node.target
-      class_attr = %( class="#{node.role}") if node.role?
-      %(<img src="#{target}" alt="#{node.attr 'alt'}"#{class_attr}/>)
+      img_attrs = [%(alt="#{node.attr 'alt'}"), %(class="inline#{node.role? ? " #{node.role}" : ''}")]
+      if target.end_with? '.svg'
+        img_attrs << %(style="width: #{node.attr 'scaledwidth', '100%'}")
+        # TODO make this a convenience method on document
+        epub_properties = (node.document.attributes['epub-properties'] ||= [])
+        epub_properties << 'svg' unless epub_properties.include? 'svg'
+      elsif node.attr? 'scaledwidth'
+        img_attrs << %(style="width: #{node.attr 'scaledwidth'}")
+      end
+      %(<img src="#{target}" #{img_attrs * ' '}/>)
     end
   end
 

--- a/lib/asciidoctor-epub3/spine_item_processor.rb
+++ b/lib/asciidoctor-epub3/spine_item_processor.rb
@@ -55,6 +55,7 @@ class SpineItemProcessor < Extensions::IncludeProcessor
         backend: 'epub3-xhtml5',
         doctype: :article,
         header_footer: true,
+        catalog_assets: true,
         attributes: inherited_attrs
 
     # restore attributes to those defined in the document header


### PR DESCRIPTION
* enable catalog_assets option on documents in spine
* read images from catalog (i.e., references) table
* move call to add_content_images method inside add_content method
* add svg to epub properties list if an inline SVG image is detected
* set width of inline image to value of scaledwidth attribute, if specified
   * if scaledwidth attribute is not specified and image is an SVG, set value to 100%
* add inline class to inline image elements
* add max-width: 100% style to all images (not just figures)
* group figure.image styles together in stylesheet