### PR TITLE
resolves #165 add support for `[horizontal]` definition list

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * add basic audio and video support (#9)
+* add support for `[horizontal]` definition list (#165)
 
 == 1.5.0.alpha.15 (2020-03-11) - @slonopotamus
 

--- a/data/styles/epub3.css
+++ b/data/styles/epub3.css
@@ -357,6 +357,11 @@ dl dd {
   margin-top: 0.25em;
 }
 
+td.hdlist1 {
+  font-weight: bold;
+  padding-right: 0.625em;
+}
+
 div.callout-list {
   margin-top: 0.5em;
 }

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -233,5 +233,31 @@ describe Asciidoctor::Epub3::Converter do
       expect(audio).not_to be_nil
       expect(audio.media_type).to eq('audio/mpeg')
     end
+
+    it 'supports horizontal dlist' do
+      book = to_epub <<~EOS
+= Article
+
+[horizontal]
+CPU:: The brain of the computer.
+Hard drive:: Permanent storage for operating system and/or user files.
+RAM:: Temporarily stores information the CPU uses during operation.
+      EOS
+
+      chapter = book.item_by_href '_article.xhtml'
+      expect(chapter).not_to be_nil
+      expect(chapter.content).to include <<~EOS
+<tr>
+<td class="hdlist1">
+<p>
+CPU
+</p>
+</td>
+<td class="hdlist2">
+<p>The brain of the computer.</p>
+</td>
+</tr>
+      EOS
+    end
   end
 end


### PR DESCRIPTION
This is the code I hacked together in an attempt to support the [horizontal] attribute for definition lists.  I'm not entirely satisfied with the result -- it turns out that horizonal lists weren't the best thing for my use case after I tried it, but others might find this useful.

This uses a table to layout horizontal lists, and the logic is adapted from the HTML layout backend.