### PR TITLE
Support font-awesome icons in admonitions

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -269,6 +269,10 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
 
   def admonition node
     id_attr = node.id ? %( id="#{node.id}") : ''
+    name = node.attr 'name'
+    if node.document.attr? 'icons'
+        if node.document.attr? 'icons', 'font') && !(node.attr? 'icon')
+            label = %(<i class="fa icon=#{name}" title=#{node.attr 'textlabel'}"></i>)
     if node.title?
       title = node.title
       title_sanitized = xml_sanitize title


### PR DESCRIPTION
I'm not entirely sure that this is correct, but I wanted to use fontawesome icons for my admonition lists to more closely match the layout used by the PDF and HTML engines.  I have some css changes in my local css to support this as well, and the result is quite satisfying.

It should also be stated that I'm a noob when it comes to CSS and front-end layout stuff.  (I'm a C programmer by trade.)  So its possible and even likely that I've gone about this all wrong.

```
--- /Users/garrett/Projects/asciidoctor-epub3/data/styles/epub3.css	2018-03-10 10:59:28.000000000 -0800
+++ epub3.css	2018-03-18 17:13:07.000000000 -0700
@@ -199,17 +199,11 @@
 }

 body a:link {
-  color: #333332;
+  /* color: #333332; */
   /* hack for font color in iBooks and Gitden (though Gitden would accept color !important too) */
-  -webkit-text-fill-color: #333332;
-  /* Kindle requires the !important on text-decoration */
   /* In night mode, the only indicator of a link is the underline, so we need it or a background image */
   text-decoration: none !important;
   border-bottom: 1px dashed #666665;
-  /* allow URLs to break anywhere if they don't fit on a line; but how do we know it's a URL? */
-  /*
-  word-break: break-all;
-  */
 }

 body:first-of-type a:link {
@@ -221,12 +215,6 @@
   background-position: 0 1.2em;
 }

-body a:visited {
-  color: #666665;
-  /* hack for font color in iBooks */
-  -webkit-text-fill-color: #666665;
-}
-
 code.literal {
   /* don't let it affect line spacing */
   /* disable since M+ 1mn won't interrupt line height */
@@ -971,49 +959,32 @@
   margin: 1.5em 2em; /* even if admonition is at bottom of block, we want that extra space below */
   padding: 0;
   border-width: 0;
+  border-spacing: 10 0;
   background: none !important;
-}
-
-aside.note {
-  border-left-color: #FFC14F;
-  background-color: #FFF0D4; /* 25% opacity of border */
-}
-
-aside.tip {
-  border-left-color: #40403E;
-  background-color: #D0D0CF; /* 25% opacity of border */
-}
-
-aside.caution {
-  border-left-color: #7F7F7D;
-  background-color: #DFDFDF; /* 25% opacity of border */
-}
-
-aside.warning {
-  border-left-color: #C83737;
-  background-color: #F1CECE; /* 25% opacity of border */
-}
-
-aside.important {
-  border-left-color: #F2642A;
-  background-color: #FCD9CA; /* 25% opacity of border */
+  display: table;
 }

 aside.admonition::before {
-  display: block;
+  display: table-cell;
   font-family: "FontAwesome";
   font-size: 2em;
   line-height: 1;
-  width: 1em;
+  width: 2em;
   text-align: center;
   margin-bottom: -0.25em;
   margin-left: -0.5em;
   text-shadow: 0px 1px 1px rgba(102, 102, 101, 0.15);
+  vertical-align: middle;
 }

 aside.admonition > div.content {
+  display: table-cell;
   font-size: 90%;
   margin-top: -1em; /* prevent at top of content when using block form of admonition */
+  vertical-align: middle;
+  padding-left: 1.125em;
+  padding-right: 1.125em;
+  border-left: 1px solid #ddddd8;
 }

 aside[class~="admonition"] > div[class~="content"] {
@@ -1022,60 +993,32 @@
   background-size: 100% 1px;
   background-repeat: no-repeat;
   background-position: 0 bottom;
-  /* template
-  background-image: -webkit-linear-gradient(left, rgba(255,255,255,0) 42.5%, <color> 45%, <color> 55%, rgba(255,255,255,0) 57.5%);
-  background-image: linear-gradient(to right, rgba(255,255,255,0) 42.5%, <color> 45%, <color> 55%, rgba(255,255,255,0) 57.5%);
-  */
 }

 aside.note::before {
-  content: "\f040"; /* fa-pencil */
-  color: #FFC14F;
-}
-
-aside[class~="note"] > div[class~="content"] {
-  background-image: -webkit-linear-gradient(left, rgba(255,255,255,0) 42.5%, #FFC14F 45%, #FFC14F 55%, rgba(255,255,255,0) 57.5%);
-  background-image: linear-gradient(to right, rgba(255,255,255,0) 42.5%, #FFC14F 45%, #FFC14F 55%, rgba(255,255,255,0) 57.5%);
+  content: "\f05a"; /* fa-circle-info */
+  color: #19407c;
 }

 aside.tip::before {
   content: "\f0eb"; /* fa-lightbulb-o */
-  color: #40403E;
-}
-
-aside[class~="tip"] > div[class~="content"] {
-  background-image: -webkit-linear-gradient(left, rgba(255,255,255,0) 42.5%, #40403E 45%, #40403E 55%, rgba(255,255,255,0) 57.5%);
-  background-image: linear-gradient(to right, rgba(255,255,255,0) 42.5%, #40403E 45%, #40403E 55%, rgba(255,255,255,0) 57.5%);
+/*  color: #171717; */
 }

 aside.caution::before {
-  content: "\f0c2"; /* fa-cloud */
-  color: #7F7F7D;
-}
-
-aside[class~="caution"] > div[class~="content"] {
-  background-image: -webkit-linear-gradient(left, rgba(255,255,255,0) 42.5%, #7F7F7D 45%, #7F7F7D 55%, rgba(255,255,255,0) 57.5%);
-  background-image: linear-gradient(to right, rgba(255,255,255,0) 42.5%, #7F7F7D 45%, #7F7F7D 55%, rgba(255,255,255,0) 57.5%);
+    content: "\f06d"; /* fa-fire */
+    color: #bf3400;
 }

 aside.warning::before {
-  content: "\f0e7"; /* fa-bolt */
-  color: #C83737;
+  content: "\f071"; /* fa-exclamation-triangle */
+  color: #bf6900;
 }

-aside[class~="warning"] > div[class~="content"] {
-  background-image: -webkit-linear-gradient(left, rgba(255,255,255,0) 42.5%, #C83737 45%, #C83737 55%, rgba(255,255,255,0) 57.5%);
-  background-image: linear-gradient(to right, rgba(255,255,255,0) 42.5%, #C83737 45%, #C83737 55%, rgba(255,255,255,0) 57.5%);
-}

 aside.important::before {
-  content: "\f12a"; /* fa-exclamation */
-  color: #F2642A;
-}
-
-aside[class~="important"] > div[class~="content"] {
-  background-image: -webkit-linear-gradient(left, rgba(255,255,255,0) 42.5%, #F2642A 45%, #F2642A 55%, rgba(255,255,255,0) 57.5%);
-  background-image: linear-gradient(to right, rgba(255,255,255,0) 42.5%, #F2642A 45%, #F2642A 55%, rgba(255,255,255,0) 57.5%);
+  content: "\f06a"; /* fa-exclamation-circle */
+  color: #bf0000;
 }

 aside.admonition > h2 {
```