### PR TITLE
Allow to unset cover image

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -928,6 +928,8 @@ Extensions.register do
   if (document = @document).backend == 'epub3'
     document.attributes['spine'] = ''
     document.set_attribute 'listing-caption', 'Listing'
+    document.set_attribute 'front-cover-image', ''
+
     if !(defined? ::AsciidoctorJ) && (::Gem::try_activate 'pygments.rb')
       if document.set_attribute 'source-highlighter', 'pygments'
         document.set_attribute 'pygments-css', 'style'

--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -151,6 +151,8 @@ module GepubBuilderMixin
           last_item['height'] = height
         end
       end
+    else
+      warn %(asciidoctor: WARNING: #{::File.basename(doc.attr 'docfile')}: front cover image not set)
     end
     nil
   end


### PR DESCRIPTION
I decided to work myself on solving issue #180.

## Changes

The converter sets `:front-cover-image:` to '' (empty) before converting the document. This differentiates it from the `nil` value it receives if the attribute is unset inside the document (`:front-cover-image!:`).

The packager can then act in three distinct ways:
* `front-image-cover == ''` use default cover
* `front-image-cover == nil` do not add the cover
* `front-image-cover != '', nil` proceed as usual

A warning is also given when the cover is unset.

## Testing

* [x] MOBI/KF8 - works correctly
* [x] EPUB3 - works correctly

I've tried using different books and setups and they all behaved correctly in both formats.

## Problems

By using an empty value as default, declaring the attribute without any value inside the document does not trigger an error.

Id est: these two headers are now equivalent and the default cover is used in  both cases.

```asciidoc
= Title

Text...
```
```asciidoc
= Title
:front-cover-image:

Text...
```

## Possible Improvements

The warning I added could be improved by looking deeper into the EPUB3 and MOBI formats and the most commons readers to check if any has problems with books lacking a cover. The `ebook-format` attribute could be used to give a more specific _cover not set_ warning.

A special default value could be used instead of empty. This would allow to consider an empty declaration in the header as an error.

## Notes

I'm completely new to Ruby, so I'm not sure I optimized the code I modified. Also, I've set the default value of the cover where I saw other document attributes being set (Under `Extension.register` at [converter.rb:927](https://github.com/asciidoctor/asciidoctor-epub3/blob/5dde009/lib/asciidoctor-epub3/converter.rb#L927)), but I'm not completely sure that was the right place.