### PR TITLE
resolves #201 fix inline anchors missing their ids

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * fix images in tables not included in epub archive (#169)
 * fix inline images not being included in epub archive (#30)
 * add support for Font Awesome Solid 5.12.0 (#155)
+* fix inline anchors missing their ids (#201)
 
 == 1.5.0.alpha.13 (2020-02-04) - @slonopotamus
 

--- a/spec/fixtures/bibliography-xref/book.adoc
+++ b/spec/fixtures/bibliography-xref/book.adoc
@@ -1,0 +1,5 @@
+= Book title
+:doctype: book
+:idprefix:
+
+include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/bibliography-xref/chapter.adoc
+++ b/spec/fixtures/bibliography-xref/chapter.adoc
@@ -1,0 +1,8 @@
+= Chapter
+
+Try to refer to <<item1>>.
+
+[bibliography]
+
+* [[[item1]]] foo::bar
+* [[[item2]]] baz::qux

--- a/spec/fixtures/inline-anchor-xref/book.adoc
+++ b/spec/fixtures/inline-anchor-xref/book.adoc
@@ -1,0 +1,6 @@
+= Book title
+:doctype: book
+:idprefix:
+:idseparator: -
+
+include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/inline-anchor-xref/chapter.adoc
+++ b/spec/fixtures/inline-anchor-xref/chapter.adoc
@@ -1,0 +1,6 @@
+= Chapter
+
+* [[item1]]foo::bar
+* [[item2]]baz::qux
+
+Try to refer to <<item1>>.

--- a/spec/xref_spec.rb
+++ b/spec/xref_spec.rb
@@ -17,5 +17,21 @@ describe 'Asciidoctor::Epub3::Converter - Xref' do
       expect(chapter_a).not_to be_nil
       expect(chapter_a.content).to include '<a id="xref--chapter-b--getting-started" href="chapter-b.xhtml#getting-started" class="xref">Getting Started</a>'
     end
+
+    it 'should resolve xref to inline anchor' do
+      book, = to_epub 'inline-anchor-xref/book.adoc'
+      chapter = book.item_by_href 'chapter.xhtml'
+      expect(chapter).not_to be_nil
+      expect(chapter.content).to include '<a id="item1"></a>foo::bar'
+      expect(chapter.content).to include '<a id="xref-item1" href="#item1" class="xref">[item1]</a>'
+    end
+
+    it 'should resolve xref to bibliography anchor' do
+      book, = to_epub 'bibliography-xref/book.adoc'
+      chapter = book.item_by_href 'chapter.xhtml'
+      expect(chapter).not_to be_nil
+      expect(chapter.content).to include '<a id="item1"></a>[item1] foo::bar'
+      expect(chapter.content).to include '<a id="xref-item1" href="#item1" class="xref">[item1]</a>'
+    end
   end
 end


### PR DESCRIPTION
In particular, some cases were using `node.target` as the `id` instead
of `node.id`.