### PR TITLE
Fix javascript cause malformed XML

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -153,6 +153,7 @@ class ContentConverter
 <link rel="stylesheet" type="text/css" href="styles/epub3.css"/>
 <link rel="stylesheet" type="text/css" href="styles/epub3-css3-only.css" media="(min-device-width: 0px)"/>
 #{icon_css_head}<script type="text/javascript">
+<![CDATA[
 document.addEventListener('DOMContentLoaded', function(event, reader) {
   if (!(reader = navigator.epubReadingSystem)) {
     if (navigator.userAgent.indexOf(' calibre/') >= 0) reader = { name: 'calibre-desktop' };
@@ -160,6 +161,7 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
   }
   document.body.setAttribute('class', reader.name.toLowerCase().replace(/ /g, '-'));
 });
+]]>
 </script>
 </head>
 <body>


### PR DESCRIPTION
Malformed XML prevents Calibre to display footnote properly, see
https://bugs.launchpad.net/calibre/+bug/1839490
Fixed by escaping with CDATA block.

If you prefer I can extract this as an external script instead.