### PR TITLE
Use imagedir from an image's context during packaging

### DIFF
--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -32,7 +32,7 @@ An extension for Asciidoctor that converts AsciiDoc documents to EPUB3 and KF8/M
 
   s.add_development_dependency 'rake', '~> 12.3.0'
 
-  s.add_runtime_dependency 'asciidoctor', '>= 1.5.0', '< 3.0.0'
+  s.add_runtime_dependency 'asciidoctor', '>= 1.5.8', '< 3.0.0'
   s.add_runtime_dependency 'gepub', '~> 1.0.0'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.0'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1.0'

--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -292,8 +292,9 @@ body > svg {
           file %(#{item.id || (item.attr 'docname')}.xhtml) => (builder.postprocess_xhtml item.convert, format)
           add_property 'svg' if ((item.attr 'epub-properties') || []).include? 'svg'
           # QUESTION should we pass the document itself?
-          item.references[:images].each do |target|
-            images[image_path = %(#{imagesdir}#{target})] ||= { docfile: docfile, path: image_path }
+          item.references[:images].each do |imageref|
+            image_path = File.join(imageref.imagesdir, imageref.target)
+            images[image_path] ||= { docfile: docfile, path: image_path }
           end
           # QUESTION reenable?
           #linear 'yes' if i == 0


### PR DESCRIPTION
As succinctly described in asciidoctor/asciidoctor#2779, `imagedir` can change throughout a document's body or via document it includes. When packaging a spine item's images, we don't recognize that, only using the spine item's top-level imagedir. This addresses that issue using the bookkeeping added in upstream 1.5.8.