### PR TITLE
Bump kindlegen dependency to 3.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,20 @@ gemspec
 
 group :optional do
   gem 'epubcheck', '3.0.1'
-  if (ruby_version = Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.0.0')
+
+  ruby_version = Gem::Version.new RUBY_VERSION
+
+  if ruby_version < (Gem::Version.new '2.0.0')
     gem 'kindlegen', '2.9.4'
+  elsif ruby_version < (Gem::Version.new '2.4.0')
+    gem 'kindlegen', '3.0.3'
+  else
+    gem 'kindlegen', '3.0.5'
+  end
+
+  if ruby_version < (Gem::Version.new '2.0.0')
     gem 'pygments.rb', '0.6.3'
   else
-    gem 'kindlegen', '3.0.3'
     gem 'pygments.rb', '1.1.2'
   end
 end


### PR DESCRIPTION
Previous kindlegen releases are unable to install in Windows.

See https://github.com/tdtds/kindlegen/pull/33