### PR TITLE
resolves #224 use epubcheck-ruby instead of epubcheck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :optional do
-  gem 'epubcheck', '3.0.1'
+  gem 'epubcheck-ruby', '4.1.1.0'
 
   if (ruby_version = Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.0.0')
     gem 'kindlegen', '2.9.4'

--- a/README.adoc
+++ b/README.adoc
@@ -466,10 +466,10 @@ Next, let's validate the EPUB3 archive to ensure it built correctly.
 .Validation success
 [.output]
 ....
-Epubcheck Version 3.0.1
-
-Validating against EPUB version 3.0
+Validating using EPUB version 3.0.1 rules.
 No errors or warnings detected.
+Messages: 0 fatal / 0 errors / 0 warnings / 0 info
+EPUBCheck completed
 ....
 
 If the EPUB3 archive contains any errors, they will be output in your terminal.
@@ -545,7 +545,7 @@ For more information about this attribute and other related attributes, see {uri
   Specifies the ebook format to generate (epub3 or kf8, default: epub3)
 
 *-a ebook-validate* ::
-  Runs Epubcheck 3.0.1 to validate output file against the EPUB3 specification
+  Runs {uri-epubcheck}[EpubCheck] to validate output file against the EPUB3 specification
 
 *-a ebook-compress=<0|1|2|none|standard|huffdic>* ::
   Controls the compression type used by kindlegen (0=none [default if unset], 1=standard [default if empty], 2=huffdic)

--- a/WORKLOG.adoc
+++ b/WORKLOG.adoc
@@ -34,10 +34,6 @@
 * allow role to be applied to chapter (which means the role must be on the document)
 * should we enable hyphens in non-Kindle?
  ** we can reenable once we confirm it doesn't crash Kindle for Mac
-* switch to epubcheck-ruby
- ** epubcheck-ruby 4.0.2
- ** supports options such as -q
- ** add -w option by default (perhaps allow additional options to be passed via the ebook-validate attribute)
 * document KINDLEGEN and EPUBCHECK env vars
 * part vs chapter? a difference?
 

--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -641,11 +641,19 @@ class Packager
   def validate_epub epub_file
     epubcheck_cmd = EPUBCHECK
     unless ::File.executable? epubcheck_cmd
-      epubcheck_cmd = ::Gem.bin_path 'epubcheck', 'epubcheck'
+      epubcheck_cmd = ::Gem.bin_path 'epubcheck-ruby', 'epubcheck'
     end
-    # NOTE epubcheck gem doesn't support epubcheck command options; enable -quiet once supported
-    ::Open3.popen2e(::Shellwords.join [epubcheck_cmd, epub_file]) {|input, output, wait_thr|
-      output.each {|line| puts line } unless $VERBOSE.nil?
+
+    argv = [epubcheck_cmd]
+    if $VERBOSE.nil?
+      argv << '-q'
+    else
+      argv << '-w'
+    end
+    argv << epub_file
+
+    ::Open3.popen2e(::Shellwords.join argv) {|input, output, wait_thr|
+      output.each {|line| puts line }
     }
   end
 end


### PR DESCRIPTION
Notes to reviewers:

1. These are the first lines of Ruby code I've ever written in my life. If they're not Ruby-way, please tell me
2. I'm not sure the way I handle `-w`/`-q` is the way @mojavelinux wants it to be
3. epubcheck-ruby 4.2.2.0 was [just released](https://github.com/takahashim/epubcheck-ruby/releases/tag/v4.2.2.0). However, it detects problems in files generated by asciidoctor-epub3, so I suggest doing 4.1.1.0 -> 4.2.2.0 upgrade in a separate PR:
```
ERROR(RSC-005): ./sample-book.epub/OEBPS/asciidoctor-epub3-a-native-epub3-converter-for-asciidoc.xhtml(23,70): Error while parsing file: element "style" not allowed here; expected the element end-tag, text, element "a", "abbr", "address", "area", "article", "aside", "audio", "b", "bdi", "bdo", "blockquote", "br", "button", "canvas", "cite", "code", "data", "datalist", "del", "details", "dfn", "dialog", "div", "dl", "em", "embed", "epub:switch", "epub:trigger", "fieldset", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "i", "iframe", "img", "input", "ins", "kbd", "label", "link", "main", "map", "mark", "menu", "meta", "meter", "nav", "ns1:math", "ns2:svg", "object", "ol", "output", "p", "picture", "pre", "progress", "q", "ruby", "s", "samp", "script", "section", "select", "small", "span", "strong", "sub", "sup", "table", "template", "textarea", "time", "u", "ul", "var", "video" or "wbr" (with xmlns:ns1="http://www.w3.org/1998/Math/MathML" xmlns:ns2="http://www.w3.org/2000/svg") or an element from another namespace
ERROR(RSC-005): ./sample-book.epub/OEBPS/asciidoctor-epub3-a-native-epub3-converter-for-asciidoc.xhtml(23,70): Error while parsing file: attribute "scoped" not allowed here; expected attribute "about", "accesskey", "aria-atomic", "aria-busy", "aria-controls", "aria-current", "aria-describedby", "aria-details", "aria-disabled", "aria-dropeffect", "aria-errormessage", "aria-expanded", "aria-flowto", "aria-grabbed", "aria-haspopup", "aria-hidden", "aria-invalid", "aria-keyshortcuts", "aria-label", "aria-labelledby", "aria-live", "aria-owns", "aria-posinset", "aria-relevant", "aria-roledescription", "aria-setsize", "autocapitalize", "class", "content", "contenteditable", "datatype", "dir", "draggable", "epub:type", "hidden", "id", "inlist", "is", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "media", "nonce", "ns:alphabet", "ns:ph", "onabort", "onautocomplete", "onautocompleteerror", "onblur", "oncancel", "oncanplay", "oncanplaythrough", "onchange", "onclick", "onclose", "oncontextmenu", "oncuechange", "ondblclick", "ondrag", "ondragend", "ondragenter", "ondragexit", "ondragleave", "ondragover", "ondragstart", "ondrop", "ondurationchange", "onemptied", "onended", "onerror", "onfocus", "onfocusin", "onfocusout", "oninput", "oninvalid", "onkeydown", "onkeypress", "onkeyup", "onload", "onloadeddata", "onloadedmetadata", "onloadstart", "onmousedown", "onmouseenter", "onmouseleave", "onmousemove", "onmouseout", "onmouseover", "onmouseup", "onpause", "onplay", "onplaying", "onprogress", "onratechange", "onreset", "onresize", "onscroll", "onseeked", "onseeking", "onselect", "onsort", "onstalled", "onsubmit", "onsuspend", "ontimeupdate", "ontoggle", "onvolumechange", "onwaiting", "onwheel", "prefix", "property", "rel", "resource", "rev", "role", "slot", "spellcheck", "style", "tabindex", "title", "translate", "type", "typeof", "vocab", "xml:base", "xml:lang" or "xml:space" (with xmlns:ns="http://www.w3.org/2001/10/synthesis")
```