### PR TITLE
Bump pygments.rb to 1.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ group :optional do
     gem 'pygments.rb', '0.6.3'
   else
     gem 'kindlegen', (ruby_version < (Gem::Version.new '2.4.0') ? '3.0.3' : '3.0.5')
-    gem 'pygments.rb', '1.1.2'
+    gem 'pygments.rb', '1.2.1'
   end
 end


### PR DESCRIPTION
 pygments.rb 1.1.2 fails if there's no find(1) on PATH (usually, Windows):

```
Errno::EACCES: Permission denied @ rb_file_s_symlink -
(vendor/pygments-main/scripts/debug_lexer.py,
C:/tools/ruby26/lib/ruby/gems/2.6.0/gems/pygments.rb-1.1.2/vendor/pygments-main/scripts/find_error.py)
An error occurred while installing pygments.rb (1.1.2), and Bundler cannot
continue.
```
This issue was fixed in pygments.rb 1.2.0: https://github.com/tmm1/pygments.rb/pull/181