### PR TITLE
Add GitHub Actions CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: eregon/use-ruby-action@master
+        with:
+          ruby-version: 2.7
+      - name: Build
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+      - name: Lint
+        run: bundle exec rake lint
+  test:
+    strategy:
+      matrix:
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, jruby]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        asciidoctor: [1.5.3, '']
+        exclude:
+          # kindlegen fails to install on 2.3 on Windows. See https://github.com/asciidoctor/asciidoctor-epub3/pull/213
+          - ruby: 2.3
+            platform: windows-latest
+          # TODO: nokogiri doesn't install on 2.7 on Windows: https://github.com/sparklemotion/nokogiri/issues/1961
+          - ruby: 2.7
+            platform: windows-latest
+          # eregon/use-ruby-action doesn't support JRUBY on Windows
+          - ruby: jruby
+            platform: windows-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: eregon/use-ruby-action@master
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Set up Asciidoctor
+        if: matrix.asciidoctor != ''
+        run: echo "::set-env name=ASCIIDOCTOR_VERSION::${{ matrix.asciidoctor }}"
+      - name: Build
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+      - name: Test
+        run: bundle exec ruby -w $(bundle exec ruby -e "print Gem.bin_path 'rake', 'rake'") spec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Publish to RubyGems.org
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: eregon/use-ruby-action@master
+      with:
+        ruby-version: 2.7
+    - name: Publish to RubyGems.org
+      uses: cadwallion/publish-rubygems-action@master
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: ruby
 cache: bundler
 bundler_args: --path=.bundle/gems --jobs=3 --retry=3 --without=docs
 rvm:
-- &release_ruby 2.7.0
+- 2.7.0
 - 2.6.5
 - 2.5.7
 - 2.4.9
@@ -26,11 +26,3 @@ env:
 script:
 - bundle exec rake lint
 - bundle exec ruby -w $(bundle exec ruby -e "print Gem.bin_path 'rake', 'rake'") spec
-deploy:
-  provider: rubygems
-  gem: asciidoctor-epub3
-  api_key: ${RUBYGEMS_API_KEY}
-  on:
-    tags: true
-    repo: asciidoctor/asciidoctor-epub3
-    rvm: *release_ruby

--- a/README.adoc
+++ b/README.adoc
@@ -29,6 +29,7 @@ endif::[]
 :uri-gem: http://rubygems.org/gems/asciidoctor-epub3
 :uri-repo: {uri-project}
 :uri-issues: {uri-repo}/issues
+:uri-ci: {uri-repo}/actions?query=workflow%3ACI
 :uri-discuss: http://discuss.asciidoctor.org
 :uri-rvm: https://rvm.io
 :uri-asciidoctor: http://asciidoctor.org
@@ -49,6 +50,7 @@ endif::[]
 ifdef::status[]
 image:https://img.shields.io/gem/v/asciidoctor-epub3.svg[Latest Release,link={uri-gem}]
 image:https://img.shields.io/badge/license-MIT-blue.svg[MIT License,link=#copyright]
+image:{uri-repo}/workflows/CI/badge.svg[GitHub Actions,link={uri-ci}]
 endif::[]
 
 {project-name} is a set of Asciidoctor extensions for converting AsciiDoc documents directly to the EPUB3 and KF8/MOBI e-book formats.


### PR DESCRIPTION
This PR introduces two GitHub Actions workflows:

1. `.github/workflows/release.yml`
Publishes gem to rubygems.org when tag is pushed to git. In order for this workflow to work, repository owner needs to set up `RUBYGEMS_API_KEY` secret in GitHub repository settings.
Note that I was unable to test whether this workflow actually works because do not have permission to push to rubygems.org.
This workflow is provided just for convenience in case if complete migration to GitHub Actions is deemed good.

2. `.github/workflows/ci.yml`
This workflow builds and tests asciidoctor-epub3 on ruby 2.3-2.7 on Linux/MacOS/Windows, except 2.3 on Windows (not supported), 2.7 on Windows (waiting for sparklemotion/nokogiri#1961) and jruby on Windows (not supported).

The reason for using GitHub Actions instead of Travis CI is the lack of Ruby-on-Windows support in the latter.

You may see example runs of CI workflow [in my fork of asciidoctor-epub3](https://github.com/slonopotamus/asciidoctor-epub3/actions?query=workflow%3ACI).