### PR TITLE
Naive rspec-based testing infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   global:
   # use system libraries to speed up installation of nokogiri
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-script: bundle exec asciidoctor-epub3 -D . data/samples/sample-book.adoc
+script: bundle exec rake spec
 deploy:
   provider: rubygems
   gem: asciidoctor-epub3

--- a/Rakefile
+++ b/Rakefile
@@ -32,50 +32,10 @@ begin
 rescue LoadError
 end
 
-=begin NOT CURRENTLY IN USE
 begin
-  require 'rake/testtask'
-  Rake::TestTask.new do |t|
-    t.libs << 'test'
-    t.pattern = 'test/**/*_test.rb'
-    t.verbose = true
-    t.warning = true
-    if RUBY_VERSION >= '2'
-      t.options = '--tty=no'
-    end
-  end
-  default_tasks << :test
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
 rescue LoadError
 end
-
-begin
-  require 'cucumber'
-  require 'cucumber/rake/task'
-  CUKE_RESULTS_FILE = 'feature-results.html'
-  ARUBA_TMP_DIR = 'tmp'
-  CLEAN << CUKE_RESULTS_FILE if File.file? CUKE_RESULTS_FILE
-  CLEAN << ARUBA_TMP_DIR if File.directory? ARUBA_TMP_DIR
-  desc 'Run features'
-  Cucumber::Rake::Task.new :features do |t|
-    opts = %(features --format html -o #{CUKE_RESULTS_FILE} --format progress -x --tags ~@pending)
-    opts = %(#{opts} --tags #{ENV['TAGS']}) if ENV['TAGS']
-    t.cucumber_opts = opts
-    t.fork = false
-  end
-
-  desc 'Run features tagged as work-in-progress (@wip)'
-  Cucumber::Rake::Task.new 'features:wip'  do |t|
-    #t.cucumber_opts = %(features --format html -o #{CUKE_RESULTS_FILE} --format pretty -x -s --tags @wip)
-    t.cucumber_opts = %(features --format html -o #{CUKE_RESULTS_FILE} --format progress -x --tags @wip)
-    t.fork = false
-  end
-
-  default_tasks << :features
-  task :cucumber => :features
-  task 'cucumber:wip' => 'features:wip'
-  task :wip => 'features:wip'
-rescue LoadError
-end
-=end
 
 task :default => default_tasks unless default_tasks.empty?

--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -31,6 +31,7 @@ An extension for Asciidoctor that converts AsciiDoc documents to EPUB3 and KF8/M
   s.require_paths = ['lib']
 
   s.add_development_dependency 'rake', '~> 12.3.0'
+  s.add_development_dependency 'rspec', '~> 3.9.0'
 
   s.add_runtime_dependency 'asciidoctor', '>= 1.5.0', '< 3.0.0'
   s.add_runtime_dependency 'gepub', '~> 1.0.0'

--- a/spec/executable_spec.rb
+++ b/spec/executable_spec.rb
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+require_relative 'spec_helper.rb'
+
+describe 'Executable' do
+  it 'exits with 0 when prints version' do
+    system 'bundle', 'exec', 'asciidoctor-epub3', '--version', :out => File::NULL, :err => File::NULL
+    expect($?.exitstatus).to eq(0)
+  end
+
+  it 'it exits with 1 when given nonexistent path' do
+    system 'bundle', 'exec', 'asciidoctor-epub3', '/nonexistent', :out => File::NULL, :err => File::NULL
+    expect($?.exitstatus).to eq(1)
+  end
+
+  it 'successfully converts sample book' do
+    sampledir = File.join(__dir__, '../data/samples/')
+    infile = File.join(sampledir, 'sample-book.adoc')
+    outfile = File.join(sampledir, 'sample-book.epub')
+
+    File.delete(outfile) if File.exist?(outfile)
+    system 'bundle', 'exec', 'asciidoctor-epub3', infile, '-o', outfile, :out => File::NULL, :err => File::NULL
+    expect($?.exitstatus).to eq(0)
+    expect(File).to exist(outfile)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+require 'rspec'
+require 'asciidoctor-epub3'


### PR DESCRIPTION
If/when this gets merged, #218 needs to be adjusted to call `bundle exec rake spec`

This PR definitely goes towards resolving #11, though scope of that issue isn't clear, so I'm not sure it counts as "resolve".