### PR TITLE
Add IntelliJ IDEA config dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea/
 /.ruby-*
 /_*/
 /Gemfile.lock


### PR DESCRIPTION
This way it doesn't show up as untracked and IDEA stops suggesting to `git add` it.