### PR TITLE
Handle ASCIIDOCTOR_VERSION env variable in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Look in asciidoctor-epub3.gemspec for runtime and development dependencies.
 gemspec
 
+gem 'asciidoctor', ENV['ASCIIDOCTOR_VERSION'], require: false if ENV.key? 'ASCIIDOCTOR_VERSION'
+
 group :optional do
   gem 'epubcheck-ruby', '4.1.1.0'
 


### PR DESCRIPTION
Commit cead09c881199388bca86dfa30df43ca2c83a175 attempted to test against asciidoctor-1.5.3 (oldest supported) on Travis.
However, unlike asciidoctor-pdf, asciidoctor-epub3 didn't have any logic for ASCIIDOCTOR_VERSION.