### PR TITLE
resolves #232 fix `-a ebook-validate` not working on Windows

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * fix installing on Windows (#213, #216)
 * upgrade pygments.rb to 1.2.1 (#216)
 * gepub dependency is no longer locked to 1.0.2 and will use latest 1.0.x version
+* fix `-a ebook-validate` not working on Windows (#232)
 
 == 1.5.0.alpha.9 (2019-04-04) - @mojavelinux
 

--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -626,10 +626,12 @@ body > svg {
       end
 
       def validate_epub epub_file
-        epubcheck_cmd = EPUBCHECK
-        epubcheck_cmd = ::Gem.bin_path 'epubcheck-ruby', 'epubcheck' unless ::File.executable? epubcheck_cmd
+        if ::File.executable? EPUBCHECK
+          argv = [EPUBCHECK]
+        else
+          argv = [::Gem.ruby, ::Gem.bin_path('epubcheck-ruby', 'epubcheck')]
+        end
 
-        argv = [epubcheck_cmd]
         if $VERBOSE.nil?
           argv << '-q'
         else

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -15,11 +15,11 @@ describe 'asciidoctor-epub3' do
     expect(err).to match(/input file \/nonexistent( is)? missing/)
   end
 
-  it 'converts sample book' do
+  it 'converts and validates sample book' do
     infile = example_file 'sample-book.adoc'
     outfile = temp_file 'sample-book.epub'
 
-    _, _, res = run_command asciidoctor_epub3_bin, infile, '-o', outfile
+    _, _, res = run_command asciidoctor_epub3_bin, '-a', 'ebook-validate', infile, '-o', outfile
     expect(res.exitstatus).to eq(0)
     expect(File).to exist(outfile)
   end


### PR DESCRIPTION
On Windows, we cannot just execute file with shebang.
Instead, invoke `ruby <file>`.
Use the same Ruby executable we're running on.