### PR TITLE
resolves #234 drop unused dependencies: thread_safe, concurrent-ruby

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 This document provides a high-level view of the changes to the {project-name} by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+* Drop unused dependencies: thread_safe, concurrent-ruby (#234)
+
 == 1.5.0.alpha.10 (2020-01-20) - @slonopotamus
 
 * fix deep xrefs between chapters when using Asciidoctor 2 (#210)

--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -37,7 +37,5 @@ An extension for Asciidoctor that converts AsciiDoc documents to EPUB3 and KF8/M
   s.add_development_dependency 'rubocop-rspec', '~> 1.37.0'
 
   s.add_runtime_dependency 'asciidoctor', '>= 1.5.0', '< 3.0.0'
-  s.add_runtime_dependency 'concurrent-ruby', '~> 1.1.0'
   s.add_runtime_dependency 'gepub', '~> 1.0.0'
-  s.add_runtime_dependency 'thread_safe', '~> 0.3.0'
 end


### PR DESCRIPTION
This will produce a warning on ancient Asciidoc versions, but this warning is harmless:

> asciidoctor: WARNING: gem 'thread_safe' is not installed. This gem is recommended when registering custom converters.