### PR TITLE
resolves #7 fix the (in)famous `undefined method `to_ios'`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * Drop unused dependencies: thread_safe, concurrent-ruby (#234)
+* Fix the (in)famous `undefined method `to_ios'` when given a document that doesn't follow asciidoctor-epub3 rules (#7)
 
 == 1.5.0.alpha.10 (2020-01-20) - @slonopotamus
 

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -27,7 +27,12 @@ module Asciidoctor
           @validate = node.attr? 'ebook-validate'
           @extract = node.attr? 'ebook-extract'
           @compress = node.attr 'ebook-compress'
-          Packager.new node, (node.references[:spine_items] || [node]), node.attributes['ebook-format'].to_sym
+          spine_items = node.references[:spine_items]
+          if spine_items.nil?
+            warn %(asciidoctor: ERROR: #{::File.basename node.document.attr('docfile')}: failed to find spine items, produced file will be invalid)
+            spine_items = []
+          end
+          Packager.new node, spine_items, node.attributes['ebook-format'].to_sym
           # converting an element from the spine document, such as an inline node in the doctitle
         elsif name.start_with? 'inline_'
           (@content_converter ||= ::Asciidoctor::Converter::Factory.default.create 'epub3-xhtml5').convert node, name

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -25,8 +25,7 @@ describe 'asciidoctor-epub3' do
   end
 
   it 'converts sample book to mobi' do
-    # TODO: https://github.com/asciidoctor/asciidoctor-epub3/issues/236
-    skip '#236: Kindlegen is unavailable for-bit MacOS' if darwin_platform?
+    skip_if_darwin
 
     infile = example_file 'sample-book.adoc'
     outfile = temp_file 'sample-book.mobi'

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe Asciidoctor::Epub3::Converter do
+  describe '#convert' do
+    it 'converts empty file to epub without exceptions' do
+      infile = fixture_file 'empty.adoc'
+      outfile = temp_file 'empty.epub'
+      Asciidoctor.convert_file infile,
+          to_file: outfile,
+          backend: 'epub3',
+          header_footer: true,
+          mkdirs: true
+      expect(File).to exist(outfile)
+    end
+
+    it 'converts empty file to mobi without exceptions' do
+      skip_if_darwin
+
+      infile = fixture_file 'empty.adoc'
+      outfile = temp_file 'empty.mobi'
+      Asciidoctor.convert_file infile,
+          to_file: outfile,
+          backend: 'epub3',
+          header_footer: true,
+          mkdirs: true,
+          attributes: { 'ebook-format' => 'mobi' }
+      expect(File).to exist(outfile)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,14 @@ RSpec.configure do |config|
     File.join temp_dir, path
   end
 
+  def fixtures_dir
+    File.join __dir__, 'fixtures'
+  end
+
+  def fixture_file path
+    File.join fixtures_dir, path
+  end
+
   def examples_dir
     File.join __dir__, '..', 'data', 'samples'
   end
@@ -53,6 +61,11 @@ RSpec.configure do |config|
 
   def darwin_platform?
     RbConfig::CONFIG['host_os'] =~ /darwin/
+  end
+
+  def skip_if_darwin
+    # TODO: https://github.com/asciidoctor/asciidoctor-epub3/issues/236
+    skip '#236: Kindlegen is unavailable for-bit MacOS' if darwin_platform?
   end
 end
 


### PR DESCRIPTION
Now asciidoctor-epub3 will just log an error when given a document that doesn't follow asciidoctor-epub3 rules

@mojavelinux I'd like your receive your approval for this