### PR TITLE
Remove symlink from sample book

### DIFF
--- a/data/samples/asciidoctor-epub3-readme.adoc
+++ b/data/samples/asciidoctor-epub3-readme.adoc
@@ -1,1 +1,0 @@
-../../README.adoc

--- a/data/samples/sample-book.adoc
+++ b/data/samples/sample-book.adoc
@@ -16,7 +16,7 @@ ifeval::["{scripts}" == "multilingual"]
 include::i18n.adoc[]
 endif::[]
 
-include::asciidoctor-epub3-readme.adoc[]
+include::../../README.adoc[]
 
 include::sample-content.adoc[]
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -19,8 +19,10 @@ describe 'asciidoctor-epub3' do
     infile = example_file 'sample-book.adoc'
     outfile = temp_file 'sample-book.epub'
 
-    _, _, res = run_command asciidoctor_epub3_bin, '-a', 'ebook-validate', infile, '-o', outfile
+    _, err, res = run_command asciidoctor_epub3_bin, '-a', 'ebook-validate', infile, '-o', outfile
     expect(res.exitstatus).to eq(0)
+    # TODO: https://github.com/asciidoctor/asciidoctor-epub3/issues/196
+    expect(err).to include 'invalid reference to anchor in unknown chapter: NOTICE'
     expect(File).to exist(outfile)
   end
 
@@ -30,8 +32,10 @@ describe 'asciidoctor-epub3' do
     infile = example_file 'sample-book.adoc'
     outfile = temp_file 'sample-book.mobi'
 
-    _, _, res = run_command asciidoctor_epub3_bin, '-a', 'ebook-format=mobi', infile, '-o', outfile
+    _, err, res = run_command asciidoctor_epub3_bin, '-a', 'ebook-format=mobi', infile, '-o', outfile
     expect(res.exitstatus).to eq(0)
+    # TODO: https://github.com/asciidoctor/asciidoctor-epub3/issues/196
+    expect(err).to include 'invalid reference to anchor in unknown chapter: NOTICE'
     expect(File).to exist(outfile)
   end
 end


### PR DESCRIPTION
Windows doesn't adequately support symlinks and even though Git for Windows has experimental symlink support, it is disabled by default.

Instead of a symlink, data/samples/asciidoctor-epub3-readme.adoc is just a regular file with following contents on Windows:

    ../../README.adoc

So, while book does produce EPUB without errors, it doesn't contain expected contents.

----

As you can [see](https://github.com/slonopotamus/asciidoctor-epub3/runs/402381008#step:6:120), bug described in #196 does not reproduce on Windows because it is hidden by a symlink bug.