### PR TITLE
Require at least Asciidoctor 1.5.3 in gemspec

### DIFF
--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -36,6 +36,6 @@ An extension for Asciidoctor that converts AsciiDoc documents to EPUB3 and KF8/M
   s.add_development_dependency 'rubocop', '~> 0.78.0'
   s.add_development_dependency 'rubocop-rspec', '~> 1.37.0'
 
-  s.add_runtime_dependency 'asciidoctor', '>= 1.5.0', '< 3.0.0'
+  s.add_runtime_dependency 'asciidoctor', '>= 1.5.3', '< 3.0.0'
   s.add_runtime_dependency 'gepub', '~> 1.0.0'
 end


### PR DESCRIPTION
Because Asciidoctor 1.5.3 is the oldest version we're testing against.