### PR TITLE
resolves #192 remove Namo Reader font-icon quirk that produced invalid markup

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * add support for Unicode characters in chapter IDs (#217)
 * fix sample-book to be a valid book (#196)
 * require at least Asciidoctor 1.5.3 (#245)
+* remove Namo Reader font-icon quirk that produced invalid markup (#192)
 * fix the (in)famous `undefined method `to_ios'` when given a document that doesn't follow asciidoctor-epub3 rules (#7)
 * route messages through the logger (#176)
 * handle invalid `revdate` gracefully (#14)

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -134,7 +134,7 @@ module Asciidoctor
         # NOTE must run after content is resolved
         # TODO perhaps create dynamic CSS file?
         if @icon_names.empty?
-          icon_css_head = icon_css_scoped = ''
+          icon_css_head = ''
         else
           icon_defs = @icon_names.map {|name|
             %(.i-#{name}::before { content: "#{FontIconMap[name.tr('-', '_').to_sym]}"; })
@@ -142,11 +142,6 @@ module Asciidoctor
           icon_css_head = %(<style>
 #{icon_defs}
 </style>
-)
-          # NOTE Namo Pubtree requires icon CSS to be repeated inside <body> (or in a linked stylesheet); wrap in div to hide from Aldiko
-          icon_css_scoped = (node.attr? 'ebook-format', 'kf8') ? '' : %(<div style="display: none" aria-hidden="true"><style scoped="scoped">
-#{icon_defs}
-</style></div>
 )
         end
 
@@ -170,7 +165,7 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
 </head>
 <body>
 <section class="chapter" title="#{doctitle_sanitized.gsub '"', '&quot;'}" epub:type="chapter" id="#{docid}">
-#{icon_css_scoped}<header>
+<header>
 <div class="chapter-header">
 #{byline}<h1 class="chapter-title">#{title}#{subtitle ? %(<small class="subtitle">#{subtitle_formatted}</small>) : ''}</h1>
 </div>


### PR DESCRIPTION
Tested using Namo Reader for Windows + Namo eBook Reader for Android.