### PR TITLE
resolves #270 make kindlegen a runtime dependency

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+* make kindlegen a runtime dependency so it installs automatically during `gem install asciidoctor-epub3` (#270)
 * make `KINDLEGEN` env var work again (#269)
 * provide a human-readable error message when we fail to find KindleGen (#268)
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'asciidoctor', ENV['ASCIIDOCTOR_VERSION'], require: false if ENV.key? 'ASCII
 
 group :optional do
   gem 'epubcheck-ruby', '4.2.2.0'
-  gem 'kindlegen', (Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.4.0') ? '3.0.3' : '3.0.5'
   gem 'pygments.rb', '1.2.1'
 end
 

--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -37,4 +37,5 @@ An extension for Asciidoctor that converts AsciiDoc documents to EPUB3 and KF8/M
 
   s.add_runtime_dependency 'asciidoctor', '>= 1.5.3', '< 3.0.0'
   s.add_runtime_dependency 'gepub', '~> 1.0.0'
+  s.add_runtime_dependency 'kindlegen', '>= 3.0.3', '<= 3.0.5'
 end


### PR DESCRIPTION
With such dependency specification, [kindlegen 3.0.3 is installed on Ruby 2.3](https://github.com/slonopotamus/asciidoctor-epub3/runs/410191198?check_suite_focus=true#step:5:46) and [kindlegen 3.0.5 is installed on newer Rubies](https://github.com/slonopotamus/asciidoctor-epub3/runs/410191235?check_suite_focus=true#step:5:43).
