### PR TITLE
make epubcheck-ruby a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 gem 'asciidoctor', ENV['ASCIIDOCTOR_VERSION'], require: false if ENV.key? 'ASCIIDOCTOR_VERSION'
 
 group :optional do
-  gem 'epubcheck-ruby', '4.2.2.0'
   gem 'pygments.rb', '1.2.1'
 end
 

--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -36,6 +36,7 @@ An extension for Asciidoctor that converts AsciiDoc documents to EPUB3 and KF8/M
   s.add_development_dependency 'rubocop-rspec', '~> 1.37.0'
 
   s.add_runtime_dependency 'asciidoctor', '>= 1.5.3', '< 3.0.0'
+  s.add_runtime_dependency 'epubcheck-ruby', '~> 4.2.2.0'
   s.add_runtime_dependency 'gepub', '~> 1.0.0'
   s.add_runtime_dependency 'kindlegen', '>= 3.0.3', '<= 3.0.5'
 end


### PR DESCRIPTION
Same as with kindlegen - without declaring dependency in gemspec, users don't get epubcheck-ruby installed when they do `gem install asciidoctor-epub3`.

epubcheck is not as critical as kindlegen, but still.