### PR TITLE
resolves #291 log KindleGen warnings with WARNING log level

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+* log KindleGen warnings with WARNING log level (#291)
 * use imagedir from an image's context during packaging (#282)
 * fix images in tables not included in epub archive (#169)
 * fix inline images not being included in epub archive (#30)

--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -650,7 +650,7 @@ body > svg {
         end
 
         out.each_line do |line|
-          logger.info line
+          log_line line
         end
         err.each_line do |line|
           log_line line
@@ -660,7 +660,7 @@ body > svg {
         if res.success?
           logger.debug %(Wrote MOBI to #{output_file})
         else
-          logger.error %(kindlegen failed to write MOBI to #{output_file})
+          logger.error %(KindleGen failed to write MOBI to #{output_file})
         end
       end
 


### PR DESCRIPTION
KindleGen writes warnings to stdout, so route its stdout throug log_line helper