### PR TITLE
resolves #203 do not include current date if `:reproducible:` attribute is set

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+* do not include current date if `:reproducible:` attribute is set (#203)
+* respect `SOURCE_DATE_EPOCH` environment variable for reproducible builds
 * fix invalid markup produced for tables with footer (#295)
 * add support for image width/height attributes (#183)
 * log KindleGen warnings with WARNING log level (#291)

--- a/lib/asciidoctor-epub3/packager.rb
+++ b/lib/asciidoctor-epub3/packager.rb
@@ -550,15 +550,22 @@ body > svg {
           # TODO: getting author list should be a method on Asciidoctor API
           contributors(*authors)
 
-          if doc.attr? 'revdate'
-            begin
-              date doc.attr('revdate')
-            rescue ArgumentError => e
-              logger.error %(#{::File.basename doc.attr('docfile')}: failed to parse revdate: #{e}, using current time as a fallback)
-              date ::Time.now
-            end
+          if doc.attr? 'reproducible'
+            # We need to set lastmodified to some fixed value. Otherwise, gepub will set it to current date.
+            @book.lastmodified (::Time.at 0).utc
+            # Is it correct that we do not populate dc:date when 'reproducible' is set?
           else
-            date ::Time.now
+            if doc.attr? 'revdate'
+              begin
+                date doc.attr('revdate')
+              rescue ArgumentError => e
+                logger.error %(#{::File.basename doc.attr('docfile')}: failed to parse revdate: #{e})
+                date doc.attr('docdatetime')
+              end
+            else
+              date doc.attr('docdatetime')
+            end
+            @book.lastmodified doc.attr('localdatetime')
           end
 
           description doc.attr('description') if doc.attr? 'description'

--- a/spec/fixtures/reproducible/book.adoc
+++ b/spec/fixtures/reproducible/book.adoc
@@ -1,0 +1,5 @@
+= Reproducible book
+:reproducible:
+:doctype: book
+
+include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/reproducible/chapter.adoc
+++ b/spec/fixtures/reproducible/chapter.adoc
@@ -1,0 +1,1 @@
+= Chapter

--- a/spec/reproducible_spec.rb
+++ b/spec/reproducible_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe Asciidoctor::Epub3::Converter do
+  it 'produces stable output for reproducible books' do
+    out_file1 = temp_file 'book1.epub'
+    out_file2 = temp_file 'book2.epub'
+    to_epub 'reproducible/book.adoc', to_file: out_file1
+    sleep 2
+    to_epub 'reproducible/book.adoc', to_file: out_file2
+    expect(FileUtils.compare_file(out_file1, out_file2)).to be true
+  end
+
+  it %(doesn't include date for reproducible books) do
+    book, = to_epub 'reproducible/book.adoc'
+    expect(book.date).to be_nil
+  end
+
+  it 'uses fixed lastmodified date for reproducible books' do
+    book, = to_epub 'reproducible/book.adoc'
+    expect(Time.parse(book.lastmodified.content)).to eq (Time.at 0).utc
+  end
+
+  it 'sets mod and creation dates to match SOURCE_DATE_EPOCH environment variable' do
+    skip %(Current Asciidoctor version doesn't support SOURCE_DATE_EPOCH) unless supports_source_date_epoch?
+
+    old_source_date_epoch = ENV.delete 'SOURCE_DATE_EPOCH'
+    begin
+      ENV['SOURCE_DATE_EPOCH'] = '1234123412'
+      book, = to_epub 'minimal/book.adoc'
+      expect(book.date.content).to eq('2009-02-08T20:03:32Z')
+      expect(book.lastmodified.content).to eq('2009-02-08T20:03:32Z')
+    ensure
+      if old_source_date_epoch
+        ENV['SOURCE_DATE_EPOCH'] = old_source_date_epoch
+      else
+        ENV.delete 'SOURCE_DATE_EPOCH'
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,11 @@ RSpec.configure do |config|
     File.join examples_dir, path
   end
 
+  # Returns true if current version of Asciidoctor supports SOURCE_DATE_EPOCH environment variable
+  def supports_source_date_epoch?
+    Gem::Version.new(Asciidoctor::VERSION) >= Gem::Version.new('1.5.5')
+  end
+
   def has_logger?
     defined? Asciidoctor::LoggerManager
   end
@@ -80,7 +85,7 @@ RSpec.configure do |config|
 
   def convert input, opts = {}
     input = fixture_file input if String === input
-    opts[:to_dir] = temp_dir unless opts.key? :to_dir
+    opts[:to_dir] = temp_dir unless opts.key?(:to_dir) || opts.key?(:to_file)
     opts[:backend] = 'epub3'
     opts[:header_footer] = true
     opts[:mkdirs] = true


### PR DESCRIPTION
Also, respect `SOURCE_DATE_EPOCH` environment variable for reproducible builds