### PR TITLE
Include id and role for inline quoting

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -79,6 +79,19 @@ module Asciidoctor
       EpubExtensionRx = /\.epub$/i
       KindlegenCompression = ::Hash['0', '-c0', '1', '-c1', '2', '-c2', 'none', '-c0', 'standard', '-c1', 'huffdic', '-c2']
 
+      (QUOTE_TAGS = {
+        monospaced: ['<code>', '</code>', true],
+        emphasis: ['<em>', '</em>', true],
+        strong: ['<strong>', '</strong>', true],
+        double: ['“', '”'],
+        single: ['‘', '’'],
+        mark: ['<mark>', '</mark>', true],
+        superscript: ['<sup>', '</sup>', true],
+        subscript: ['<sub>', '</sub>', true],
+        asciimath: ['<code>', '</code>', true],
+        latexmath: ['<code>', '</code>', true],
+      }).default = ['', '']
+
       def initialize backend, opts = {}
         super
         basebackend 'html'
@@ -982,26 +995,27 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
       end
 
       def convert_inline_quoted node
-        case node.type
-        when :strong
-          %(<strong>#{node.text}</strong>)
-        when :emphasis
-          %(<em>#{node.text}</em>)
-        when :monospaced, :asciimath, :latexmath
-          # TODO: implement proper stem support. See https://github.com/asciidoctor/asciidoctor-epub3/issues/10
-          %(<code class="literal">#{node.text}</code>)
-        when :double
-          #%(&#x201c;#{node.text}&#x201d;)
-          %(“#{node.text}”)
-        when :single
-          #%(&#x2018;#{node.text}&#x2019;)
-          %(‘#{node.text}’)
-        when :superscript
-          %(<sup>#{node.text}</sup>)
-        when :subscript
-          %(<sub>#{node.text}</sub>)
+        open, close, tag = QUOTE_TAGS[node.type]
+
+        # TODO: implement proper stem support. See https://github.com/asciidoctor/asciidoctor-epub3/issues/10
+        node.add_role 'literal' if [:monospaced, :asciimath, :latexmath].include? node.type
+
+        if node.id
+          class_attr = class_string node
+          if tag
+            %(#{open.chop} id="#{node.id}"#{class_attr}>#{node.text}#{close})
+          else
+            %(<span id="#{node.id}"#{class_attr}>#{open}#{node.text}#{close}</span>)
+          end
+        elsif role_valid_class? node.role
+          class_attr = class_string node
+          if tag
+            %(#{open.chop}#{class_attr}>#{node.text}#{close})
+          else
+            %(<span#{class_attr}>#{open}#{node.text}#{close}</span>)
+          end
         else
-          node.text
+          %(#{open}#{node.text}#{close})
         end
       end
 
@@ -1478,6 +1492,21 @@ body > svg {
         else
           logger.info line
         end
+      end
+
+      private
+
+      def class_string node
+        role = node.role
+
+        return '' unless role_valid_class? role
+
+        %( class="#{role}")
+      end
+
+      # Handles asciidoctor 1.5.6 quirk when role can be parent
+      def role_valid_class? role
+        role.is_a? String
       end
     end
 

--- a/spec/fixtures/inline-quote/book.adoc
+++ b/spec/fixtures/inline-quote/book.adoc
@@ -1,0 +1,6 @@
+= Book title
+:doctype: book
+:idprefix:
+:idseparator: -
+
+include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/inline-quote/chapter.adoc
+++ b/spec/fixtures/inline-quote/chapter.adoc
@@ -1,0 +1,13 @@
+= Chapter
+
+[.inline-quote]##Knowledge kills action; action requires the veils of illusion.##
+
+*enclosed in asterisk characters*
+
++enclosed in plus characters+
+
+`single grave accent to the left and a single acute accent to the right'
+
+``two grave accents to the left and two acute accents to the right''
+
+#hashes around text#

--- a/spec/inline_quoted_spec.rb
+++ b/spec/inline_quoted_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'Asciidoctor::Epub3::Converter - Inline Quoted' do
+  subject { Asciidoctor::Epub3::Converter.new('epub3').convert_inline_quoted node }
+
+  let(:parent) { instance_double('parent').as_null_object }
+  let(:node) { Asciidoctor::Inline.new parent, :bar, 'text', type: type }
+
+  it 'resolves inline quotes' do
+    book, = to_epub 'inline-quote/book.adoc'
+    chapter = book.item_by_href 'chapter.xhtml'
+    expect(chapter).not_to be_nil
+    expect(chapter.content).to include '<p><span class="inline-quote">Knowledge kills action; action requires the veils of illusion.</span></p>'
+    expect(chapter.content).to include '<p><strong>enclosed in asterisk characters</strong></p>'
+    expect(chapter.content).to include '<p>enclosed in plus characters</p>'
+    expect(chapter.content).to include "<p>`single grave accent to the left and a single acute accent to the right'</p>"
+    expect(chapter.content).to include "<p>``two grave accents to the left and two acute accents to the right''</p>"
+    expect(chapter.content).to include '<p><mark>hashes around text</mark></p>'
+  end
+
+  context 'double' do
+    let(:type) { :double }
+
+    it 'wraps with double quotes' do
+      expect(subject).to eq(%(“text”))
+    end
+  end
+
+  context 'single' do
+    let(:type) { :single }
+
+    it 'wraps with single quotes' do
+      expect(subject).to eq(%(‘text’))
+    end
+  end
+
+  context 'strong' do
+    let(:type) { :strong }
+
+    it 'renders as strong element' do
+      expect(subject).to eq('<strong>text</strong>')
+    end
+  end
+
+  context 'monospaced' do
+    let(:type) { :monospaced }
+
+    it 'renders as code element' do
+      expect(subject).to eq('<code class="literal">text</code>')
+    end
+  end
+
+  context 'asciimath' do
+    let(:type) { :asciimath }
+
+    it 'renders as code element' do
+      expect(subject).to eq('<code class="literal">text</code>')
+    end
+  end
+
+  context 'latexmath' do
+    let(:type) { :latexmath }
+
+    it 'renders as code element' do
+      expect(subject).to eq('<code class="literal">text</code>')
+    end
+  end
+
+  context 'with role' do
+    let :node do
+      Asciidoctor::Inline.new parent, :bar, 'text', type: type, attributes: { 'role' => 'foo' }
+    end
+
+    context 'emphasis' do
+      let(:type) { :emphasis }
+
+      it 'puts role as class' do
+        expect(subject).to eq('<em class="foo">text</em>')
+      end
+    end
+
+    context 'double' do
+      let(:type) { :double }
+
+      it 'wraps with span element and puts role as class' do
+        expect(subject).to eq('<span class="foo">“text”</span>')
+      end
+    end
+
+    context 'custom type' do
+      let(:type) { :custom_type }
+
+      it 'wraps with span element and puts role as class' do
+        expect(subject).to eq('<span class="foo">text</span>')
+      end
+    end
+  end
+
+  context 'with id' do
+    let(:node) { Asciidoctor::Inline.new parent, :bar, 'text', type: type, id: 'ID' }
+
+    context 'emphasis' do
+      let(:type) { :emphasis }
+
+      it 'puts role as class' do
+        expect(subject).to eq('<em id="ID">text</em>')
+      end
+    end
+
+    context 'double' do
+      let(:type) { :double }
+
+      it 'wraps with span element and puts role as class' do
+        expect(subject).to eq('<span id="ID">“text”</span>')
+      end
+    end
+
+    context 'custom type' do
+      let(:type) { :custom_type }
+
+      it 'wraps with span element and puts role as class' do
+        expect(subject).to eq('<span id="ID">text</span>')
+      end
+    end
+  end
+
+  context 'with id and role' do
+    let :node do
+      Asciidoctor::Inline.new parent, :bar, 'text', type: type, id: 'ID', attributes: { 'role' => 'foo' }
+    end
+
+    context 'emphasis' do
+      let(:type) { :emphasis }
+
+      it 'puts role as class' do
+        expect(subject).to eq('<em id="ID" class="foo">text</em>')
+      end
+    end
+
+    context 'double' do
+      let(:type) { :double }
+
+      it 'wraps with span element and puts role as class' do
+        expect(subject).to eq('<span id="ID" class="foo">“text”</span>')
+      end
+    end
+
+    context 'custom type' do
+      let(:type) { :custom_type }
+
+      it 'wraps with span element and puts role as class' do
+        expect(subject).to eq('<span id="ID" class="foo">text</span>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on [`Asciidoctor::Converter::Html5Converter`](https://github.com/asciidoctor/asciidoctor/blob/master/lib/asciidoctor/converter/html5.rb).

* allowing wrapping with `<span>`
* allowing specifying id
* allowing specifying class via `role`