### PR TITLE
add support for multiple authors in book metadata

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * add support for Font Awesome Solid 5.12.0 (#155)
 * fix inline anchors missing their ids (#201)
 * support multiple front-matter files via `epub3-frontmatterdir` attribute
+* add support for multiple authors in book metadata
 
 == 1.5.0.alpha.13 (2020-02-04) - @slonopotamus
 

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -96,5 +96,41 @@ describe Asciidoctor::Epub3::Converter do
       expect(chapter).not_to be_nil
       expect(chapter.content).to include '<p>Hello</p>'
     end
+
+    it 'adds no book authors if there are none' do
+      book, = to_epub 'author/book-no-author.adoc'
+      expect(book.creator).to be_nil
+      expect(book.creator_list.size).to eq(0)
+    end
+
+    it 'adds a single book author' do
+      book, = to_epub 'author/book-one-author.adoc'
+      expect(book.creator).not_to be_nil
+      expect(book.creator.content).to eq('Author One')
+      expect(book.creator.role.content).to eq('aut')
+      expect(book.creator_list.size).to eq(1)
+    end
+
+    it 'adds multiple book authors' do
+      book, = to_epub 'author/book-multiple-authors.adoc'
+      expect(book.metadata.creator).not_to be_nil
+      expect(book.metadata.creator.content).to eq('Author One')
+      expect(book.metadata.creator.role.content).to eq('aut')
+      expect(book.creator_list.size).to eq(2)
+      expect(book.metadata.creator_list[0].content).to eq('Author One')
+      expect(book.metadata.creator_list[1].content).to eq('Author Two')
+    end
+
+    it 'adds the publisher if both publisher and producer are defined' do
+      book, = to_epub 'author/book-one-author.adoc'
+      expect(book.publisher).not_to be_nil
+      expect(book.publisher.content).to eq('MyPublisher')
+    end
+
+    it 'adds the producer as publisher if no publisher is defined' do
+      book, = to_epub 'author/book-no-author.adoc'
+      expect(book.publisher).not_to be_nil
+      expect(book.publisher.content).to eq('MyProducer')
+    end
   end
 end

--- a/spec/fixtures/author/book-multiple-authors.adoc
+++ b/spec/fixtures/author/book-multiple-authors.adoc
@@ -1,0 +1,5 @@
+= Minimal book
+Author One; Author Two
+:doctype: book
+
+include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/author/book-no-author.adoc
+++ b/spec/fixtures/author/book-no-author.adoc
@@ -1,0 +1,4 @@
+= Minimal book
+:doctype: book
+:producer: MyProducer
+include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/author/book-one-author.adoc
+++ b/spec/fixtures/author/book-one-author.adoc
@@ -1,0 +1,6 @@
+= Minimal book
+Author One
+:doctype: book
+:publisher: MyPublisher
+:producer: MyProducer
+include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/author/chapter.adoc
+++ b/spec/fixtures/author/chapter.adoc
@@ -1,0 +1,1 @@
+= Chapter


### PR DESCRIPTION
remove (for now) attributed creator links for books because Kindle can't handle them

closes #109