### PR TITLE
Add darker font color recipe to kindle oasis too.

### DIFF
--- a/data/styles/epub3-css3-only.css
+++ b/data/styles/epub3-css3-only.css
@@ -100,8 +100,8 @@ body code, body kbd, body pre, pre :not(code) {
   }
 }
 
-/* Use darker font colors on Kindle Paperwhite */
-@media amzn-kf8 and (device-height: 1024px) and (device-width: 758px), amzn-kf8 and (device-height: 758px) and (device-width: 1024px) {
+/* Use darker font colors on Kindle Paperwhite and Oasis */
+@media amzn-kf8 and (device-height: 1024px) and (device-width: 758px), amzn-kf8 and (device-height: 758px) and (device-width: 1024px), amzn-kf8 and (device-height: 1680px) and (device-width: 1264px), amzn-kf8 and (device-height: 1264px) and (device-width: 1680px) {
   body p,
   div.abstract > p,
   ul, ol, li, dl, dt, dd, footer,


### PR DESCRIPTION
According to Wikipedia, Kindle Oasis has a definition of
1680 × 1264 pixels, 300 ppi. And according to #67, we can only detect
the model of kindle by its definition. We just apply the same recipe
as for PaperWhite here.

Please note that this PR was not tested on a real device, but was triggered by https://github.com/progit/progit2/issues/1438