### PR TITLE
resolves #123 remove <b> from chapter subtitle

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+* remove <b> from chapter subtitle (#123)
 * fix chapter titles to actually be chapter titles instead of document title (#343)
 * store syntax highlighter CSS in a separate file (#339)
 * initial landmarks support: appendix, bibliography, bodymatter, cover, frontmatter, glossary, index, preface, toc (#174)

--- a/data/styles/epub3-css3-only.css
+++ b/data/styles/epub3-css3-only.css
@@ -75,23 +75,6 @@ body code, body kbd, body pre, pre :not(code) {
   th, td, figcaption, caption {
     text-rendering: optimizeLegibility;
   }*/
-  /* hack line height of subtitle using floats on Kindle */
-  h1.chapter-title .subtitle {
-    margin-top: -0.2em;
-    margin-bottom: 0.3em; /* compensate for reduced line height */
-  }
-
-  /* NOTE using b instead of span since Firefox ePubReader applies immutable styles to span */
-  h1.chapter-title .subtitle > b {
-    float: left;
-    display: inline-block;
-    margin-bottom: -0.3em; /* reduce the line height */
-    padding-right: 0.2em; /* spacing between words */
-  }
-
-  h1.chapter-title .subtitle > b:last-child {
-    padding-right: 0;
-  }
 
   h1.chapter-title .subtitle::after {
     display: table;

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -343,11 +343,6 @@ module Asciidoctor
           subtitle = nil
         end
 
-        # By default, Kindle does not allow the line height to be adjusted.
-        # But if you float the elements, then the line height disappears and can be restored manually using margins.
-        # See https://github.com/asciidoctor/asciidoctor-epub3/issues/123
-        subtitle_formatted = subtitle ? subtitle.split.map {|w| %(<b>#{w}</b>) } * ' ' : nil
-
         if node.document.doctype == 'book'
           byline = ''
         else
@@ -379,7 +374,7 @@ module Asciidoctor
 
         header = (title || subtitle) ? %(<header>
 <div class="chapter-header">
-#{byline}<h1 class="chapter-title">#{title}#{subtitle ? %(<small class="subtitle">#{subtitle_formatted}</small>) : ''}</h1>
+#{byline}<h1 class="chapter-title">#{title}#{subtitle ? %(<small class="subtitle">#{subtitle}</small>) : ''}</h1>
 </div>
 </header>) : ''
 

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -76,7 +76,7 @@ describe Asciidoctor::Epub3::Converter do
       appendix = book.items[spine[1].idref]
       expect(appendix).not_to be_nil
       expect(appendix.href).to eq('appendix.xhtml')
-      expect(appendix.content).to include('<b>Appendix</b> <b>A:</b> <b>Appendix</b>')
+      expect(appendix.content).to include('Appendix A: Appendix')
     end
 
     it 'supports section numbers' do
@@ -89,7 +89,7 @@ describe Asciidoctor::Epub3::Converter do
       EOS
       chapter = book.item_by_href '_chapter.xhtml'
       expect(chapter).not_to be_nil
-      expect(chapter.content).to include('<b>1.</b> <b>Chapter</b>')
+      expect(chapter.content).to include('1. Chapter')
     end
 
     it 'converts multi-part book' do


### PR DESCRIPTION
Center: what we have currently
Left: what was suggested in #125 
Right: what this PR does

![adjusted_b](https://user-images.githubusercontent.com/92637/86400470-559ff100-bcb1-11ea-8995-da5cbbe0f858.png)

While I personally like current visuals more, there are reasons in #123 why `<b>` is problematic.