### PR TITLE
resolves #10 add support for MathML

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * fix chapter titles to actually be chapter titles instead of document title (#343)
 * store syntax highlighter CSS in a separate file (#339)
 * initial landmarks support: appendix, bibliography, bodymatter, cover, frontmatter, glossary, index, preface, toc (#174)
+* add support for MathML (#10)
 
 == 1.5.0.alpha.17 (2020-05-25) - @slonopotamus
 

--- a/README.adoc
+++ b/README.adoc
@@ -107,6 +107,7 @@ Of course, there's always room for improvement, so we'll continue to work with y
 * Orphan section titles avoided (so much as it's supported by the e-reader)
 * Table border settings honored
 * Support for SVG images in the content
+* Stem blocks via AsciiMath
 
 === Project Status
 

--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -31,6 +31,7 @@ An extension for Asciidoctor that converts AsciiDoc documents to EPUB3 and KF8/M
   s.require_paths = ['lib']
 
   s.add_development_dependency 'asciidoctor-diagram', '>= 1.5.0', '< 3.0.0'
+  s.add_development_dependency 'asciimath', '~> 1.0'
   s.add_development_dependency 'coderay', '~> 1.1.0'
   s.add_development_dependency 'pygments.rb', '~> 1.2.0'
   s.add_development_dependency 'rake', '~> 13.0.0'

--- a/spec/fixtures/inline-stem.adoc
+++ b/spec/fixtures/inline-stem.adoc
@@ -1,3 +1,4 @@
-= Chapter
+= Article
+:stem: asciimath
 
 Inline stem: stem:[y=x^2 sqrt(4)]

--- a/spec/fixtures/inline-stem/book.adoc
+++ b/spec/fixtures/inline-stem/book.adoc
@@ -1,4 +1,0 @@
-= Inline stem book
-:doctype: book
-
-include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/stem.adoc
+++ b/spec/fixtures/stem.adoc
@@ -1,0 +1,6 @@
+= Article
+
+[asciimath,title=Math]
+++++
+y=x^2 sqrt(4)
+++++

--- a/spec/fixtures/stem/book.adoc
+++ b/spec/fixtures/stem/book.adoc
@@ -1,4 +1,0 @@
-= Stem book
-:doctype: book
-
-include::chapter.adoc[leveloffset=+1]

--- a/spec/fixtures/stem/chapter.adoc
+++ b/spec/fixtures/stem/chapter.adoc
@@ -1,6 +1,0 @@
-= Chapter
-
-[latexmath]
-++++
-\sqrt(4) = 2
-++++

--- a/spec/inline_quoted_spec.rb
+++ b/spec/inline_quoted_spec.rb
@@ -52,14 +52,6 @@ describe 'Asciidoctor::Epub3::Converter - Inline Quoted' do
     end
   end
 
-  context 'asciimath' do
-    let(:type) { :asciimath }
-
-    it 'renders as code element' do
-      expect(subject).to eq('<code class="literal">text</code>')
-    end
-  end
-
   context 'latexmath' do
     let(:type) { :latexmath }
 

--- a/spec/stem_spec.rb
+++ b/spec/stem_spec.rb
@@ -3,17 +3,21 @@
 require_relative 'spec_helper'
 
 describe 'Asciidoctor::Epub3::Converter - Stem' do
-  it 'converts stem block to <pre>' do
-    book, = to_epub fixture_file('stem/book.adoc')
-    chapter = book.item_by_href '_chapter.xhtml'
+  it 'supports mathml stem blocks' do
+    book, = to_epub fixture_file('stem.adoc')
+    chapter = book.item_by_href 'stem.xhtml'
     expect(chapter).not_to be_nil
-    expect(chapter.content).to include '<pre>\sqrt(4) = 2</pre>'
+    expect(chapter.content).to include '<figcaption>Math</figcaption>
+<div class="content">
+<mml:math><mml:mi>y</mml:mi><mml:mo>=</mml:mo><mml:msup><mml:mi>x</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:msqrt><mml:mn>4</mml:mn></mml:msqrt></mml:math>
+</div>
+</figure>'
   end
 
-  it 'converts inline stem to <code>' do
-    book, = to_epub fixture_file('inline-stem/book.adoc')
-    chapter = book.item_by_href '_chapter.xhtml'
+  it 'supports inline mathml' do
+    book, = to_epub fixture_file('inline-stem.adoc')
+    chapter = book.item_by_href 'inline-stem.xhtml'
     expect(chapter).not_to be_nil
-    expect(chapter.content).to include '<code class="literal">y=x^2 sqrt(4)</code>'
+    expect(chapter.content).to include 'Inline stem: <code class="literal"><mml:math><mml:mi>y</mml:mi><mml:mo>=</mml:mo><mml:msup><mml:mi>x</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:msqrt><mml:mn>4</mml:mn></mml:msqrt></mml:math></code>'
   end
 end


### PR DESCRIPTION
A quick screenshot of how [test stem document](https://github.com/asciidoctor/asciidoctor-epub3/blob/e1431f75c3b0d3f4ee7cdffd2830c68e6da7e211/spec/fixtures/stem.adoc) looks in Calibre:

![image](https://user-images.githubusercontent.com/92637/86410367-53df2900-bcc3-11ea-8062-f00015613742.png)
