### PR TITLE
#366 fixing the visited color for links in dark mode in Apple Books

### DIFF
--- a/data/styles/epub3.css
+++ b/data/styles/epub3.css
@@ -248,6 +248,13 @@ body a:visited {
   -webkit-text-fill-color: #333332;
 }
 
+/* change link color for visited in iBooks Night mode */
+:root[__ibooks_internal_theme*="Night"] body a:visited {
+    color: initial;
+    /* hack for font color in iBooks */
+    -webkit-text-fill-color: initial;
+}
+
 code.literal {
   /* don't let it affect line spacing */
   /* disable since M+ 1mn won't interrupt line height */


### PR DESCRIPTION
It looks like the problem of the unreadable links concerns the visited links. In the pull request I've reset them to the original color, but only for Apple Books Night mode.

More info can be found here:
https://stackoverflow.com/questions/14305164/any-way-to-detect-if-dark-theme-is-active-in-ibooks-from-within-epub

and here:
http://epubsecrets.com/how-to-access-the-web-inspector-for-desktop-ibooks.php