### PR TITLE
resolves #382 use width attribute if image width is in pixels

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -992,12 +992,21 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
         img_attrs = []
         img_attrs << %(alt="#{node.attr 'alt'}") if node.attr? 'alt'
 
-        width = node.attr 'scaledwidth'
-        width = node.attr 'width' if width.nil?
-
         # Unlike browsers, Calibre/Kindle *do* scale image if only height is specified
         # So, in order to match browser behavior, we just always omit height
-        img_attrs << %(style="width: #{width}") unless width.nil?
+
+        if (scaledwidth = node.attr 'scaledwidth')
+          img_attrs << %(style="width: #{scaledwidth}")
+        elsif (width = node.attr 'width')
+          # HTML5 spec (and EPUBCheck) only allows pixels in width, but browsers also accept percents
+          # and there are multiple AsciiDoc files in the wild that have width=percents%
+          # So, for compatibility reasons, output percentage width as a CSS style
+          if width[/^\d+%$/]
+            img_attrs << %(style="width: #{width}")
+          else
+            img_attrs << %(width="#{width}")
+          end
+        end
 
         img_attrs
       end

--- a/spec/fixtures/image-dimensions/chapter.adoc
+++ b/spec/fixtures/image-dimensions/chapter.adoc
@@ -3,3 +3,5 @@
 image::square.png[100x100,100,100]
 image::square.png[50x50,50,50]
 image::square.png[50x?,50]
+image::square.png[25%x?,25%]
+image::square.png[invalid,25em]

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -68,6 +68,8 @@ describe 'Asciidoctor::Epub3::Converter - Image' do
     expect(chapter.content).to include '<img src="square.png" alt="100x100" width="100" />'
     expect(chapter.content).to include '<img src="square.png" alt="50x50" width="50" />'
     expect(chapter.content).to include '<img src="square.png" alt="50x?" width="50" />'
+    expect(chapter.content).to include '<img src="square.png" alt="25%x?" style="width: 25%" />'
+    expect(chapter.content).to include '<img src="square.png" alt="invalid" width="25em" />'
   end
 
   # If this test fails for you, make sure you're using gepub >= 1.0.11


### PR DESCRIPTION
otherwise, use CSS style because HTML5 only allows pixels in width="..."

See https://www.w3.org/TR/2011/WD-html5-20110113/the-map-element.html#attr-dim-width

> The width and height attributes on img, iframe, embed, object, video, and, when their type attribute is in the Image Button state,
> input elements may be specified to give the dimensions of the visual content of the element (the width and height respectively,
> relative to the nominal direction of the output medium), in CSS pixels.
> The attributes, if specified, must have values that are valid non-negative integers.