### PR TITLE
define project-name attribute before document title to fix a warning in Asciidoctor 2

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,11 +1,10 @@
+:project-name: Asciidoctor EPUB3
+:project-handle: asciidoctor-epub3
 = {project-name} Documentation
 Dan Allen <https://github.com/mojavelinux[@mojavelinux]>; Sarah White <https://github.com/graphitefriction[@graphitefriction]>
 // Settings:
 :navtitle: Introduction
 :experimental:
-// Aliases:
-:project-name: Asciidoctor EPUB3
-:project-handle: asciidoctor-epub3
 // URIs:
 :uri-asciidoctor: https://asciidoctor.org/
 :uri-idpf: http://www.idpf.org/


### PR DESCRIPTION
I think the problem is that this attribute is used in the page title, and some places in the Antora pipeline don't support that use case unless the attribute is defined in the component descriptor. This is the best short-term fix.