### PR TITLE
resolves #363: reenable dependency on kindlegen gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
     needs: activate
     strategy:
       matrix:
-        ruby: [jruby, '2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
+        # TODO: Use 'jruby-9.2' when https://github.com/jruby/jruby/issues/6648 is fixed
+        ruby: ['jruby-9.2.16', '2.4', '2.5', '2.6', '2.7', '3.0']
         os: [ubuntu-latest, windows-latest]
         asciidoctor: ['']
         include:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,9 +8,11 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 == Unreleased
 
 * update Font Awesome Solid to 5.15.1
-* use CSS for image size scaling instead of `width` attribute. #382
+* use CSS for image size scaling instead of `width` attribute (#382)
 * use pygments.rb 2.0.0 in CI
 * add support for `:back-cover-image:` document attribute (#396)
+* reenable Kindlegen support (#363)
+* drop support for Ruby 2.3
 
 == 1.5.0.alpha.19 (2020-10-21) - @slonopotamus
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,6 @@ end
 group :optional do
   # epubcheck-ruby might be safe to be converted into runtime dependency, but could have issues when packaged into asciidoctorj-epub3
   gem 'epubcheck-ruby', '~> 4.2.5.0'
+  # Kindlegen is unavailable neither for 64-bit MacOS nor for ARM
+  gem 'kindlegen', '~> 3.1.0' unless RbConfig::CONFIG['host_os'] =~ /darwin/
 end

--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -17,7 +17,7 @@ An extension for Asciidoctor that converts AsciiDoc documents to EPUB3 and KF8/M
   s.homepage = 'https://github.com/asciidoctor/asciidoctor-epub3'
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.4.0'
 
   files = begin
     (result = Open3.popen3('git ls-files -z') {|_, out| out.read }.split %(\0)).empty? ? Dir['**/*'] : result

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -1658,8 +1658,15 @@ body > svg {
           return [result]
         end
 
-        logger.debug 'Using KindleGen from PATH'
-        [%(kindlegen#{::Gem.win_platform? ? '.exe' : ''})]
+        begin
+          require 'kindlegen' unless defined? ::Kindlegen
+          result = ::Kindlegen.command.to_s
+          logger.debug %(Using KindleGen from gem: #{result})
+          [result]
+        rescue LoadError => e
+          logger.debug %(#{e}; Using KindleGen from PATH)
+          [%(kindlegen#{::Gem.win_platform? ? '.exe' : ''})]
+        end
       end
 
       def distill_epub_to_mobi epub_file, target, compress

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,9 @@ RSpec.configure do |config|
   end
 
   def skip_unless_has_kindlegen
-    skip 'KindleGen is gone: https://github.com/asciidoctor/asciidoctor-epub3/issues/363'
+    require 'kindlegen'
+  rescue LoadError
+    skip 'kindlegen gem is unavailable'
   end
 
   def convert input, opts = {}


### PR DESCRIPTION
This commit also drops support for Ruby < 2.4

This reverts commit 33e27eeb21fb62f1e82767f9957a0a03fa35c722.