### PR TITLE
resolves #422 add user-select:none to i.conum

### DIFF
--- a/data/styles/epub3.css
+++ b/data/styles/epub3.css
@@ -394,6 +394,7 @@ i.conum {
   color: #468C54;
   font-family: "M+ 1mn", monospace;
   font-style: normal;
+  user-select: none;
 }
 
 /* don't let conum affect line spacing; REVIEW may not need this! */


### PR DESCRIPTION
as discussed in
https://github.com/asciidoctor/asciidoctor-epub3/issues/422

i added user-select: none to i.conum.

older linux versions of calibre did not support this, but it has been fixed recently

this allows copying code examples from the ebook without the callouts.