### PR TITLE
Switch to sass-embedded

### DIFF
--- a/asciidoctor-epub3.gemspec
+++ b/asciidoctor-epub3.gemspec
@@ -44,6 +44,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'gepub', '~> 1.0.0'
   s.add_runtime_dependency 'mime-types', '~> 3.0'
 
-  # TODO: switch to 'sass-embedded' when we drop Ruby 2.5 support
-  s.add_runtime_dependency 'sass'
+  s.add_runtime_dependency 'sass-embedded', '~> 1.58'
 end

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -2,7 +2,7 @@
 
 require 'mime/types'
 require 'open3'
-require 'sass'
+require 'sass-embedded'
 require_relative 'font_icon_map'
 
 module Asciidoctor
@@ -1698,10 +1698,7 @@ body > svg {
       end
 
       def load_css_file(filename)
-        template = File.read filename
-        load_paths = [File.dirname(filename)]
-        sass_engine = Sass::Engine.new template, syntax: :scss, cache: false, load_paths: load_paths, style: :compressed
-        sass_engine.render
+        Sass.compile(filename, style: :compressed).css
       end
 
       def build_epubcheck_command


### PR DESCRIPTION
This PR switches to use sass-embedded (dart-sass) to compile scss stylesheets.