### PR TITLE
feat: :sparkles: Honour roles for items in olists and ulists

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -952,7 +952,9 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
         lines << %(<h3 class="list-heading">#{node.title}</h3>) if node.title?
         lines << %(<ol#{ol_class_attr}#{ol_start_attr}#{node.option?('reversed') ? ' reversed="reversed"' : ''}>)
         node.items.each do |item|
-          lines << %(<li>
+          li_classes = [item.style, item.role].compact
+          li_class_attr = li_classes.empty? ? '' : %( class="#{li_classes * ' '}")
+          lines << %(<li#{li_class_attr}>
 <span class="principal">#{item.text}</span>)
           if item.blocks?
             lines << item.content
@@ -979,7 +981,9 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
         lines << %(<h3 class="list-heading">#{node.title}</h3>) if node.title?
         lines << %(<ul#{ul_class_attr}>)
         node.items.each do |item|
-          lines << %(<li>
+          li_classes = [item.style, item.role].compact
+          li_class_attr = li_classes.empty? ? '' : %( class="#{li_classes * ' '}")
+          lines << %(<li#{li_class_attr}>
 <span class="principal">#{item.text}</span>)
           if item.blocks?
             lines << item.content


### PR DESCRIPTION
Usually list items do not have extra roles (AsciiDoc does not allow roles in list items as per today), but they can be added via processors.
This PR honour the roles, and inject them into the generated list items.