### PR TITLE
fix sidebar deep link

### DIFF
--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -735,6 +735,7 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
       end
 
       def convert_sidebar(node)
+        id_attribute = node.id ? %( id="#{node.id}") : ''
         classes = ['sidebar']
         if node.title?
           classes << 'titled'
@@ -747,7 +748,7 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
           title_attr = title_el = ''
         end
 
-        %(<aside class="#{classes * ' '}"#{title_attr} epub:type="sidebar">
+        %(<aside#{id_attribute} class="#{classes * ' '}"#{title_attr} epub:type="sidebar">
 #{title_el}<div class="content">
 #{output_content node}
 </div>

--- a/spec/xref_spec.rb
+++ b/spec/xref_spec.rb
@@ -83,4 +83,20 @@ describe 'Asciidoctor::Epub3::Converter - Xref' do
     expect(article).not_to be_nil
     expect(article.content).to include '<a id="xref-_subsection" href="#_subsection" class="xref">link text</a>'
   end
+
+  it 'adds xref id to sidebar' do
+    book = to_epub <<~EOS
+      = Article
+
+      [id=one]
+      ****
+      This is a sidebar
+      ****
+
+      More text
+    EOS
+    article = book.item_by_href '_article.xhtml'
+    expect(article).not_to be_nil
+    expect(article.content).to include '<aside id="one" class="sidebar" epub:type="sidebar">'
+  end
 end


### PR DESCRIPTION
Adds `id` attribute support to sidebar.

Fixes "Fragment identifier is not defined." error when trying to deep-link a sidebar. For example:

```
ERROR(RSC-012): foo.epub/EPUB/_chapter.xhtml(LINE,COLUMN): Fragment identifier is not defined.
```