### PR TITLE
Sort definitions in SCSS files to make them pass validators

### DIFF
--- a/data/styles/epub3-css3-only.scss
+++ b/data/styles/epub3-css3-only.scss
@@ -64,7 +64,7 @@ body code, body kbd, body :not(.verse) > pre, :not(.verse) > pre :not(code) {
 .icon {
   display: inline-block;
   /* !important required to override custom font setting in Kindle (since .icon can appear inside a span) */
-  font-family: "FontAwesome" !important;
+  font-family: "Font Awesome 6 Free Solid", monospace !important;
   font-style: normal !important;
   font-weight: normal !important;
   line-height: 1;

--- a/data/styles/epub3-fonts.scss
+++ b/data/styles/epub3-fonts.scss
@@ -37,14 +37,14 @@
 }
 
 @font-face {
-  font-family: "M+ 1p";
+  font-family: "M+ 1p light";
   font-style: normal;
   font-weight: 200;
   src: url(../fonts/mplus1p-light-latin.ttf);
 }
 
 @font-face {
-  font-family: "M+ 1p";
+  font-family: "M+ 1p bold";
   font-style: normal;
   font-weight: 700;
   src: url(../fonts/mplus1p-bold-latin.ttf);
@@ -82,7 +82,7 @@
 }
 
 @font-face {
-  font-family: "FontAwesome";
+  font-family: "Font Awesome 6 Free Solid";
   font-style: normal;
   font-weight: normal;
   src: url(../fonts/awesome/fa-solid-900.ttf);

--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -1045,6 +1045,38 @@ table.table th {
   font-weight: bold;
 }
 
+table.table-grid-all th,
+table.table-grid-all td {
+  border-width: 1px 1px 1px 1px;
+  border-style: solid;
+  border-color: $table-border;
+}
+
+hr.pagebreak {
+  -webkit-column-break-after: always;
+  page-break-after: always;
+  border: none;
+  margin: 0;
+}
+
+/* REVIEW */
+hr.pagebreak + * {
+  margin-top: 0 !important;
+}
+
+#_about_the_author {
+  -webkit-column-break-before: always;
+  page-break-before: always;
+  border-bottom: 1px solid $about-author-border;
+}
+
+table.table-grid-cols th,
+table.table-grid-cols td {
+  border-width: 0 1px 0 0;
+  border-style: solid;
+  border-color: $table-border;
+}
+
 table.table thead th {
   border-bottom: 1px solid $table-border;
 }
@@ -1078,32 +1110,9 @@ table.table-framed-sides {
   border-color: $table-border;
 }
 
-table.table-grid-all th,
-table.table-grid-all td {
-  border-width: 1px 1px 1px 1px;
-  border-style: solid;
-  border-color: $table-border;
-}
-
-table.table-grid-all thead tr > *:last-child {
-  border-right-width: 0;
-}
-
-table.table-grid-all tbody tr:last-child > th,
-table.table-grid-all tbody tr:last-child > td {
-  border-bottom-width: 0;
-}
-
 table.table-grid-rows tbody th,
 table.table-grid-rows tbody td {
   border-width: 1px 0 0 0;
-  border-style: solid;
-  border-color: $table-border;
-}
-
-table.table-grid-cols th,
-table.table-grid-cols td {
-  border-width: 0 1px 0 0;
   border-style: solid;
   border-color: $table-border;
 }
@@ -1116,28 +1125,19 @@ table.table-grid-cols tbody tr > td:last-child {
   border-right-width: 0;
 }
 
+table.table-grid-all thead tr > *:last-child {
+  border-right-width: 0;
+}
+
+table.table-grid-all tbody tr:last-child > th,
+table.table-grid-all tbody tr:last-child > td {
+  border-bottom-width: 0;
+}
+
 pre.pygments span.linenos,
 pre.rouge span.linenos {
   display: inline-block;
   margin-right: 0.75em;
-}
-
-hr.pagebreak {
-  -webkit-column-break-after: always;
-  page-break-after: always;
-  border: none;
-  margin: 0;
-}
-
-/* REVIEW */
-hr.pagebreak + * {
-  margin-top: 0 !important;
-}
-
-#_about_the_author {
-  -webkit-column-break-before: always;
-  page-break-before: always;
-  border-bottom: 1px solid $about-author-border;
 }
 
 img.headshot {

--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -72,7 +72,7 @@ kbd {
 
 .menuseq .caret {
   /*
-  font-family: "FontAwesome";
+  font-family: "Font Awesome 6 Free Solid", monospace;
   font-size: 0.7em;
   line-height: 1;
   font-weight: bold;
@@ -87,7 +87,7 @@ kbd {
 }
 
 .menuseq .caret::before {
-  font-family: "FontAwesome";
+  font-family: "Font Awesome 6 Free Solid", monospace;
   content: "\f054";
   font-size: 0.6em;
   vertical-align: 0.15em;
@@ -121,7 +121,7 @@ sup {
   /*
   display: inline-block;
   vertical-align: text-top;
-  padding-top: .25em;
+  padding-top: 0.25em;
   */
   /* alternate approach #2 */
   line-height: 1;
@@ -138,7 +138,7 @@ sub {
   /*
   display: inline-block;
   vertical-align: text-bottom;
-  padding-bottom: .5em;
+  padding-bottom: 0.5em;
   */
   /* alternate approach #2 */
   line-height: 1;
@@ -147,27 +147,27 @@ sub {
 
 /* We need to apply text-align to <p> too in order to override global text-align:justify */
 th.halign-left, td.halign-left, th.halign-left > p, td.halign-left > p {
-  text-align: left
+  text-align: left;
 }
 
 th.halign-right, td.halign-right, th.halign-right > p, td.halign-right > p {
-  text-align: right
+  text-align: right;
 }
 
 th.halign-center, td.halign-center, th.halign-center > p, td.halign-center > p {
-  text-align: center
+  text-align: center;
 }
 
 th.valign-top, td.valign-top, th.valign-top > p, td.valign-top > p {
-  vertical-align: top
+  vertical-align: top;
 }
 
 th.valign-bottom, td.valign-bottom, th.valign-bottom > p, td.valign-bottom > p {
-  vertical-align: bottom
+  vertical-align: bottom;
 }
 
 th.valign-middle, td.valign-middle, th.valign-middle > p, td.valign-middle > p {
-  vertical-align: middle
+  vertical-align: middle;
 }
 
 body a:link {
@@ -254,7 +254,7 @@ th, td, figcaption, caption {
 p.last::after {
   color: $last-mark-text;
   display: inline-block;
-  font-family: "FontAwesome";
+  font-family: "Font Awesome 6 Free Solid", monospace;
   font-size: 1em;
   content: "\f121"; /* i.e., </> */
   margin-left: 0.25em;
@@ -476,12 +476,13 @@ h4 {
   color: $h4-header-text;
   font-weight: 200;
 
-  font-size: 1.1em;
-  margin-top: 1em; /* 1.1rem */
-  margin-bottom: -0.818em; /* -0.9rem, 0.1rem to content */
+  /* Removed due to multiple definitions, assuming only the last one will be considered by interpreters */
+  /* font-size: 1.1em; */
+  /* margin-top: 1em; */ /* 1.1rem */
+  /* margin-bottom: -0.818em; */ /* -0.9rem, 0.1rem to content */
 
   font-size: 1.2em;
-  margin-top: .917em; /* 1.1rem */
+  margin-top: 0.917em; /* 1.1rem */
   margin-top: 0.875em; /* 1.05rem */
   /*margin-bottom: -0.75em;*/
   /* -0.9rem, 0.1rem to content */
@@ -724,7 +725,7 @@ aside.sidebar > h2 {
   display: inline-block;
   white-space: nowrap; /* for some reason it's wrapping prematurely */
   border: 1px solid $aside-border;
-  padding: 1.5em .75em .5em .75em;
+  padding: 1.5em 0.75em 0.5em 0.75em;
   margin: -1em 0.5em -0.25em 0.5em;
   background-color: $body-background;
   /*
@@ -775,19 +776,19 @@ blockquote > p:first-of-type::before {
   text-shadow: 0 1px 2px rgba(102, 102, 101, 0.3);
 
   /* using serif quote from entypo */
-  font-family: "FontIcons";
+  font-family: "FontIcons", monospace;
 
   /*content: "\f10e";*/
   /* quote-right from Entypo */
   /*
   -webkit-transform: rotate(180deg);
   transform: rotate(180deg);
-  padding-left: .3em;
-  padding-right: .2em;
+  padding-left: 0.3em;
+  padding-right: 0.2em;
   */
 
   content: "\f10d"; /* quote-left, a flipped version of the quote-right from Entypo */
-  padding-right: .5em;
+  padding-right: 0.5em;
   font-size: 1.5em;
   line-height: 1.3;
   margin-top: -0.5em;
@@ -900,7 +901,7 @@ aside.important {
 
 aside.admonition::before {
   display: block;
-  font-family: "FontAwesome";
+  font-family: "Font Awesome 6 Free Solid", monospace;
   font-size: 2em;
   line-height: 1;
   width: 1em;

--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -195,6 +195,15 @@ body p {
   orphans: 2;
 }
 
+th, td {
+  /* forward-compatible CSS to enable kerning (if we want ligatures, add "liga" and "dlig") */
+  /* WebKits that don't recognize these properties don't kern well, hence why we don't simply enable kerning via text-rendering */
+  -webkit-font-feature-settings: "kern";
+  font-feature-settings: "kern";
+  font-kerning: normal;
+  /* NOTE see Kindle hack in epub3-css3-only.css for additional kerning settings (disabled) */
+}
+
 body p,
 ul, ol, li, dl, dt, dd, footer,
 div.verse .attribution, table.table th, table.table td,
@@ -217,7 +226,7 @@ code, kbd, pre {
 /* QUESTION should we kern preformatted text blocks? */
 h1, h2, h3, h4, h5, h6,
 body p, li, dd, blockquote > footer,
-th, td, figcaption, caption {
+figcaption, caption {
   /* forward-compatible CSS to enable kerning (if we want ligatures, add "liga" and "dlig") */
   /* WebKits that don't recognize these properties don't kern well, hence why we don't simply enable kerning via text-rendering */
   -webkit-font-feature-settings: "kern";
@@ -238,6 +247,58 @@ p.last::after {
 ul li, ol li {
   /* minimum margin in case there is no paragraph content */
   margin-top: 0.4em;
+}
+
+ul {
+  /* QUESTION do we need important here? */
+  margin-left: 1em !important;
+
+  > li::before {
+    float: left;
+    margin-left: -1em;
+    margin-top: -0.05em;
+    padding-left: 0.25em;
+    /* guarantee it's out of the flow */
+    width: 0;
+    display: block;
+
+    content: "▪";
+    color: $list-lvl1;
+  }
+
+  ul {
+    > li::before {
+      content: "◦";
+      color: $list-lvl2;
+    }
+
+    ul {
+      > li::before {
+        content: "•";
+        color: $list-lvl3;
+      }
+
+      ul {
+        > li::before {
+          content: "▫";
+          color: $list-lvl4;
+        }
+      }
+    }
+  }
+}
+
+ol {
+  list-style-type: decimal;
+  margin-left: 1.75em !important;
+
+  ol {
+    list-style-type: lower-alpha;
+
+    ol {
+      list-style-type: lower-roman;
+    }
+  }
 }
 
 /* use paragraph-size gaps between list items */
@@ -263,11 +324,6 @@ dt > span.term > code.literal {
   font-style: normal;
 }
 */
-
-dl dd {
-  /* minimum margin in case there is no paragraph content */
-  margin-top: 0.25em;
-}
 
 td.hdlist1 {
   font-weight: bold;
@@ -342,61 +398,14 @@ div.stack-subject li strong.subject {
   display: block;
 }
 
-ul {
-  /* QUESTION do we need important here? */
-  margin-left: 1em !important;
-
-  > li::before {
-    float: left;
-    margin-left: -1em;
-    margin-top: -0.05em;
-    padding-left: 0.25em;
-    /* guarantee it's out of the flow */
-    width: 0;
-    display: block;
-
-    content: "▪";
-    color: $list-lvl1;
-  }
-
-  ul {
-    > li::before {
-      content: "◦";
-      color: $list-lvl2;
-    }
-
-    ul {
-      > li::before {
-        content: "•";
-        color: $list-lvl3;
-      }
-
-      ul {
-        > li::before {
-          content: "▫";
-          color: $list-lvl4;
-        }
-      }
-    }
-  }
-}
-
-ol {
-  list-style-type: decimal;
-  margin-left: 1.75em !important;
-
-  ol {
-    list-style-type: lower-alpha;
-
-    ol {
-      list-style-type: lower-roman;
-    }
-  }
-}
-
 /* REVIEW */
 dd {
   margin-left: 1.5rem !important;
+}
+
+dl dd {
+  /* minimum margin in case there is no paragraph content */
+  margin-top: 0.25em;
 }
 
 /* Kindle does not justify list-item element, must wrap in nested block element */
@@ -428,6 +437,16 @@ li strong.subject a:link {
 ul.bibliography > li > span.principal,
 ul.references > li > span.principal {
   text-align: left;
+}
+
+figure.image {
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+figure.image img {
+  display: block;
+  margin: 0 auto;
 }
 
 /* sized based on the major third modular scale (4:5, 16px, 24px) */
@@ -725,6 +744,25 @@ th.valign-middle, td.valign-middle, th.valign-middle > p, td.valign-middle > p {
   vertical-align: middle;
 }
 
+div.verse {
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+/* TODO we may want to reenable hyphens here */
+div.verse > pre {
+  font-family: "M+ 1p", sans-serif;
+  background-color: transparent;
+  border: none;
+  font-size: 1.2em;
+  text-align: center;
+}
+
+div.verse .attribution {
+  display: block;
+  margin-top: 1.4em;
+}
+
 figure,
 aside.sidebar {
   margin-top: 1em;
@@ -738,16 +776,6 @@ aside.sidebar {
   margin-bottom: 1em;
 }
 */
-
-figure.image {
-  -webkit-column-break-inside: avoid;
-  page-break-inside: avoid;
-}
-
-figure.image img {
-  display: block;
-  margin: 0 auto;
-}
 
 figure.coalesce {
   -webkit-column-break-inside: avoid;
@@ -834,25 +862,6 @@ aside.sidebar > div.content {
 /* QUESTION same for ordered-list? */
 aside.sidebar > div.content > div.itemized-list > ul {
   margin-left: 0.5em !important;
-}
-
-div.verse {
-  -webkit-column-break-inside: avoid;
-  page-break-inside: avoid;
-}
-
-/* TODO we may want to reenable hyphens here */
-div.verse > pre {
-  font-family: "M+ 1p", sans-serif;
-  background-color: transparent;
-  border: none;
-  font-size: 1.2em;
-  text-align: center;
-}
-
-div.verse .attribution {
-  display: block;
-  margin-top: 1.4em;
 }
 
 aside.admonition {

--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -145,31 +145,6 @@ sub {
   vertical-align: text-bottom;
 }
 
-/* We need to apply text-align to <p> too in order to override global text-align:justify */
-th.halign-left, td.halign-left, th.halign-left > p, td.halign-left > p {
-  text-align: left;
-}
-
-th.halign-right, td.halign-right, th.halign-right > p, td.halign-right > p {
-  text-align: right;
-}
-
-th.halign-center, td.halign-center, th.halign-center > p, td.halign-center > p {
-  text-align: center;
-}
-
-th.valign-top, td.valign-top, th.valign-top > p, td.valign-top > p {
-  vertical-align: top;
-}
-
-th.valign-bottom, td.valign-bottom, th.valign-bottom > p, td.valign-bottom > p {
-  vertical-align: bottom;
-}
-
-th.valign-middle, td.valign-middle, th.valign-middle > p, td.valign-middle > p {
-  vertical-align: middle;
-}
-
 body a:link {
   /* Kindle requires the !important on text-decoration */
   /* In night mode, the only indicator of a link is the underline, so we need it or a background image */
@@ -276,6 +251,7 @@ dt {
   page-break-inside: avoid;
   -webkit-column-break-after: avoid;
   page-break-after: avoid;
+  margin-top: 0.75em; /* balances 0.25em to term */
 }
 
 dt > span.term {
@@ -287,10 +263,6 @@ dt > span.term > code.literal {
   font-style: normal;
 }
 */
-
-dt {
-  margin-top: 0.75em; /* balances 0.25em to term */
-}
 
 dl dd {
   /* minimum margin in case there is no paragraph content */
@@ -582,6 +554,101 @@ h1.chapter-title b {
   width: 2em !important;
 }
 
+div.blockquote {
+  padding: 0 1em;
+  margin: 1.25em auto;
+}
+
+/* display: table causes quotes to be repeated in Aldiko, so we hide this part */
+div[class~="blockquote"] {
+  display: table;
+}
+
+blockquote > p {
+  color: $blockquote-text;
+  font-style: italic;
+
+  /*
+  font-size: 1.2em;
+  word-spacing: 0.1em;
+  */
+
+  font-size: 1.15em;
+  word-spacing: 0.1em;
+
+  margin-top: 0;
+  line-height: 1.75;
+}
+
+blockquote > p:first-of-type::before {
+  display: inline-block;
+  color: $para-first-text;
+  text-shadow: 0 1px 2px rgba(102, 102, 101, 0.3);
+
+  /* using serif quote from entypo */
+  font-family: "FontIcons", monospace;
+
+  /*content: "\f10e";*/
+  /* quote-right from Entypo */
+  /*
+  -webkit-transform: rotate(180deg);
+  transform: rotate(180deg);
+  padding-left: 0.3em;
+  padding-right: 0.2em;
+  */
+
+  content: "\f10d"; /* quote-left, a flipped version of the quote-right from Entypo */
+  padding-right: 0.5em;
+  font-size: 1.5em;
+  line-height: 1.3;
+  margin-top: -0.5em;
+  vertical-align: text-bottom;
+}
+
+blockquote footer {
+  font-size: 0.9em;
+  font-style: italic;
+
+  margin-top: 0.5rem;
+  text-align: right;
+}
+
+blockquote footer .context {
+  font-size: 0.9em;
+  letter-spacing: -0.05em;
+  color: $footer-context;
+}
+
+pre {
+  text-align: left; /* fix for Namo */
+  margin-top: 1em; /* 0.85rem */
+  /*margin-top: 1.176em;*/
+  /* 1rem */
+  white-space: pre-wrap;
+  overflow-wrap: break-word; /* break in middle of long word if no other break opportunities are available */
+  font-size: 0.85em;
+  line-height: 1.4; /* matches what Kindle uses and can't go less */
+  background-color: $pre-background;
+  padding: 8px 12px; /* this is supposed to be '0.5rem 0.75rem' but Sony Readers crash when see that (at least, PRS-350, PRS-505, PRS-T1) */
+  border-top: 1px solid $pre-border;
+  border-right: 1px solid $pre-border;
+}
+
+/* TODO what we really want is for pre w/o caption to be unbreakable */
+pre.screen {
+  /*
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+  */
+  orphans: 3;
+  widows: 3; /* widows doesn't seem to work here */
+}
+
+pre.source {
+  orphans: 3;
+  widows: 3; /* widows doesn't seem to work here */
+}
+
 div.abstract {
   margin: 5% 1.5em 2.5em 1.5em;
 }
@@ -631,6 +698,31 @@ p.stack-head > strong.head {
 
 p.signature {
   font-size: 0.9em;
+}
+
+/* We need to apply text-align to <p> too in order to override global text-align:justify */
+th.halign-left, td.halign-left, th.halign-left > p, td.halign-left > p {
+  text-align: left;
+}
+
+th.halign-right, td.halign-right, th.halign-right > p, td.halign-right > p {
+  text-align: right;
+}
+
+th.halign-center, td.halign-center, th.halign-center > p, td.halign-center > p {
+  text-align: center;
+}
+
+th.valign-top, td.valign-top, th.valign-top > p, td.valign-top > p {
+  vertical-align: top;
+}
+
+th.valign-bottom, td.valign-bottom, th.valign-bottom > p, td.valign-bottom > p {
+  vertical-align: bottom;
+}
+
+th.valign-middle, td.valign-middle, th.valign-middle > p, td.valign-middle > p {
+  vertical-align: middle;
 }
 
 figure,
@@ -742,101 +834,6 @@ aside.sidebar > div.content {
 /* QUESTION same for ordered-list? */
 aside.sidebar > div.content > div.itemized-list > ul {
   margin-left: 0.5em !important;
-}
-
-div.blockquote {
-  padding: 0 1em;
-  margin: 1.25em auto;
-}
-
-/* display: table causes quotes to be repeated in Aldiko, so we hide this part */
-div[class~="blockquote"] {
-  display: table;
-}
-
-blockquote > p {
-  color: $blockquote-text;
-  font-style: italic;
-
-  /*
-  font-size: 1.2em;
-  word-spacing: 0.1em;
-  */
-
-  font-size: 1.15em;
-  word-spacing: 0.1em;
-
-  margin-top: 0;
-  line-height: 1.75;
-}
-
-blockquote > p:first-of-type::before {
-  display: inline-block;
-  color: $para-first-text;
-  text-shadow: 0 1px 2px rgba(102, 102, 101, 0.3);
-
-  /* using serif quote from entypo */
-  font-family: "FontIcons", monospace;
-
-  /*content: "\f10e";*/
-  /* quote-right from Entypo */
-  /*
-  -webkit-transform: rotate(180deg);
-  transform: rotate(180deg);
-  padding-left: 0.3em;
-  padding-right: 0.2em;
-  */
-
-  content: "\f10d"; /* quote-left, a flipped version of the quote-right from Entypo */
-  padding-right: 0.5em;
-  font-size: 1.5em;
-  line-height: 1.3;
-  margin-top: -0.5em;
-  vertical-align: text-bottom;
-}
-
-blockquote footer {
-  font-size: 0.9em;
-  font-style: italic;
-
-  margin-top: 0.5rem;
-  text-align: right;
-}
-
-blockquote footer .context {
-  font-size: 0.9em;
-  letter-spacing: -0.05em;
-  color: $footer-context;
-}
-
-pre {
-  text-align: left; /* fix for Namo */
-  margin-top: 1em; /* 0.85rem */
-  /*margin-top: 1.176em;*/
-  /* 1rem */
-  white-space: pre-wrap;
-  overflow-wrap: break-word; /* break in middle of long word if no other break opportunities are available */
-  font-size: 0.85em;
-  line-height: 1.4; /* matches what Kindle uses and can't go less */
-  background-color: $pre-background;
-  padding: 8px 12px; /* this is supposed to be '0.5rem 0.75rem' but Sony Readers crash when see that (at least, PRS-350, PRS-505, PRS-T1) */
-  border-top: 1px solid $pre-border;
-  border-right: 1px solid $pre-border;
-}
-
-/* TODO what we really want is for pre w/o caption to be unbreakable */
-pre.screen {
-  /*
-  -webkit-column-break-inside: avoid;
-  page-break-inside: avoid;
-  */
-  orphans: 3;
-  widows: 3; /* widows doesn't seem to work here */
-}
-
-pre.source {
-  orphans: 3;
-  widows: 3; /* widows doesn't seem to work here */
 }
 
 div.verse {
@@ -992,6 +989,27 @@ aside[class~="admonition"] > h2 {
   margin-bottom: 0;
 }
 
+div.footnotes {
+  margin-top: 1em;
+}
+
+div.footnotes p {
+  font-size: 0.8rem;
+  margin-top: 0.4rem;
+}
+
+div.footnotes sup.noteref {
+  font-weight: bold;
+  font-size: 0.9em;
+}
+
+/*div.footnotes sup.noteref a {*/
+sup.noteref a {
+  /* Kindle wants to underline these links */
+  text-decoration: none !important;
+  background-image: none;
+}
+
 div.table {
   margin-top: 1em;
 }
@@ -1126,27 +1144,6 @@ img.headshot {
 .chapter-footer {
   -webkit-column-break-before: always;
   page-break-before: always;
-}
-
-div.footnotes {
-  margin-top: 1em;
-}
-
-div.footnotes p {
-  font-size: 0.8rem;
-  margin-top: 0.4rem;
-}
-
-div.footnotes sup.noteref {
-  font-weight: bold;
-  font-size: 0.9em;
-}
-
-/*div.footnotes sup.noteref a {*/
-sup.noteref a {
-  /* Kindle wants to underline these links */
-  text-decoration: none !important;
-  background-image: none;
 }
 
 nav#toc ol {


### PR DESCRIPTION
I came across *asciidoctor-epub3* some time ago and use it for my own projects. Back then I already noticed that the CSS files placed into the resulting \*.epub file were causing many warnings and errors in validators.

So, after using it for some years now, I finally got the time to fix all the issues. I verified my changes with the hardware I have at hand here (read:  Calibre 7.6.0 and my dusty Kobo GloHD with firmware version 3.19.5761 from December 2015). Both readers don't show any differences in the tests I did, but I can't cover all devices out there, of course.

There have been no changes in the semantics, just changes in the order of the individual CSS definitions.

I would kindly ask to review my changes and get them integrated at some point, but I also noticed that the files follow a more visual approach in the order they define the individual styles: from top to bottom. Header and chapter definitions come first in the files, then the stuff which goes into the content area (tables, paragraphs, images, ...) and finally there are definitions for footers. So I would also understand if my changes are not considered an improvement and keeping the current order being favored.