### PR TITLE
Center caption text of block images

### DIFF
--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -801,6 +801,7 @@ figure.image figcaption {
   margin-top: 0.2em;
   -webkit-column-break-after: auto;
   page-break-after: auto;
+  text-align: center;
 }
 
 p + figure.listing,


### PR DESCRIPTION
Rationale: see Amazon's [Image Guidelines - Reflowable](https://kdp.amazon.com/en_US/help/topic/G75V4YX5X8GRGXWV), item 2, "Quality of images", item c, "Images with captions". Closes #418.