### PR TITLE
Make terms in description lists bolded rather than italicized

### DIFF
--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -316,7 +316,7 @@ dt {
 }
 
 dt > span.term {
-  font-style: italic;
+  font-weight: bold;
 }
 
 /*


### PR DESCRIPTION
Rationale: for consistency with the HTML and PDF backends. Closes #494.