### PR TITLE
Add style for `example-title`

### DIFF
--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -363,6 +363,12 @@ div.callout-list li > i.conum {
   width: 1.25em;
 }
 
+div.example-title {
+  display: block;
+  font-family: "M+ 1p", sans-serif;
+  font-style: italic;
+}
+
 div.itemized-list, div.ordered-list, div.description-list {
   margin-top: 1em;
   padding-bottom: 0.25em; /* REVIEW maybe, maybe not */


### PR DESCRIPTION
Makes optional title for example block stand out. Closes #504

Output:

![image](https://github.com/user-attachments/assets/23f1f915-eb4f-48da-a5dc-fa7d9f6d1e95)
