### PR TITLE
Generate linked index in EPUB3 output

### DIFF
--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -418,6 +418,24 @@ dl dd {
   margin-top: 0.25em;
 }
 
+.index-category {
+  > :first-child {
+    margin-top: 1.5em;
+  }
+
+  .index-entries {
+    margin-left: 1.5em;
+  }
+
+  > .index-entries {
+    margin-left: 0;
+  }
+
+  .index-entry {
+    margin-bottom: 0.25em;
+  }
+}
+
 /* Kindle does not justify list-item element, must wrap in nested block element */
 li > span.principal, dd > span.principal {
   display: block;

--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -419,6 +419,9 @@ dl dd {
 }
 
 .index-category {
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+
   > :first-child {
     margin-top: 1.5em;
     margin-bottom: 0.25em;

--- a/data/styles/epub3.scss
+++ b/data/styles/epub3.scss
@@ -421,6 +421,7 @@ dl dd {
 .index-category {
   > :first-child {
     margin-top: 1.5em;
+    margin-bottom: 0.25em;
   }
 
   .index-entries {

--- a/lib/asciidoctor-epub3/converter.rb
+++ b/lib/asciidoctor-epub3/converter.rb
@@ -160,6 +160,7 @@ module Asciidoctor
       end
 
       def convert_document(node)
+        @index_section = node.find_by(context: :section).find { |section| section.sectname == 'index' }
         @validate = node.attr? 'ebook-validate'
         @extract = node.attr? 'ebook-extract'
         @compress = node.attr 'ebook-compress'
@@ -386,7 +387,7 @@ module Asciidoctor
         mark_last_paragraph node unless node.document.doctype == 'book'
 
         @xrefs_seen.clear
-        content = node.content
+        content = node.respond_to?(:sectname) && node.sectname == 'index' ? convert_index_section(node) : node.content
 
         # NOTE: must run after content is resolved
         # TODO perhaps create dynamic CSS file?
@@ -511,6 +512,67 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
           #{content})
                                                    end}
 </section>)
+      end
+
+      def convert_index_section(node)
+        content = node.content
+        index = node.document.catalog[:indexterms]
+        return content unless index && !index.empty?
+
+        index.link_associations
+        result = content.empty? ? [] : [content]
+        index.categories.each do |category|
+          result << %(<div class="index-category">
+<h2>#{category.name}</h2>
+#{convert_index_terms category.terms, node}
+</div>)
+        end
+        result.join LF
+      end
+
+      def convert_index_terms(terms, index_section)
+        result = ['<div class="index-entries" role="list">']
+        terms.each do |term|
+          entry = %(<div id="#{term.anchor}" class="index-entry" role="listitem">#{term.name}#{convert_index_term_references term, index_section})
+          unless term.leaf?
+            entry = %(#{entry}
+#{convert_index_terms term.subterms, index_section})
+          end
+          result << %(#{entry}</div>)
+        end
+        result << '</div>'
+        result.join LF
+      end
+
+      def convert_index_term_references(term, index_section)
+        if (see = term.see)
+          %(, see #{convert_index_association see})
+        else
+          result = term.dests.map do |dest|
+            href = index_destination_href dest, index_section
+            %(<a href="#{href}">#{index_destination_label dest[:node], index_section.document}</a>)
+          end
+          if (see_also = term.see_also)
+            result << %(see also #{see_also.map { |associated_term| convert_index_association associated_term }.join ', '})
+          end
+          result.empty? ? '' : %(, #{result.join '; '})
+        end
+      end
+
+      def convert_index_association(term)
+        term.respond_to?(:anchor) ? %(<a href="##{term.anchor}">#{term.name}</a>) : term.name
+      end
+
+      def index_destination_href(dest, index_section)
+        source = dest[:node]
+        anchor = %i[section document].include?(source.context) && source.id ? source.id : dest[:anchor]
+        chapter = get_enclosing_chapter source
+        chapter == index_section ? %(##{anchor}) : %(#{get_chapter_filename chapter}.xhtml##{anchor})
+      end
+
+      def index_destination_label(node, doc)
+        node = node.parent until node.nil? || node.context == :section
+        node ? node.xreftext : (doc.doctitle use_fallback: true)
       end
 
       # NOTE: embedded is used for AsciiDoc table cell content
@@ -1307,7 +1369,8 @@ document.addEventListener('DOMContentLoaded', function(event, reader) {
       end
 
       def convert_inline_indexterm(node)
-        node.type == :visible ? node.text : ''
+        text = node.type == :visible ? node.text : ''
+        node.id && @index_section ? %(<span id="#{node.id}" class="indexterm"></span>#{text}) : text
       end
 
       def convert_inline_kbd(node)

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'generated index' do
+  it 'links nested and repeated terms across chapter files' do
+    book = to_epub <<~'EOS'
+      = Felines
+      :doctype: book
+
+      == Cats
+
+      A https://example.org[((tiger))].
+      (((Animals, Cats, Tiger)))
+
+      == Dogs
+
+      Another ((tiger)).
+
+      [index]
+      == Index
+
+      Index introduction.
+    EOS
+
+    cats = book.item_by_href '_cats.xhtml'
+    dogs = book.item_by_href '_dogs.xhtml'
+    index = book.item_by_href '_index.xhtml'
+
+    expect(cats.content).to include '<a href="https://example.org" class="link"><span id="__indexterm-1" class="indexterm"></span>tiger</a>'
+    expect(dogs.content).to include '<span id="__indexterm-3" class="indexterm"></span>tiger'
+    expect(index.content).to include '<div class="index-category">'
+    expect(index.content).to include '<div class="index-entries" role="list">'
+    expect(index.content).to include 'href="_cats.xhtml#__indexterm-1"'
+    expect(index.content).to include 'href="_dogs.xhtml#__indexterm-3"'
+    expect(index.content).to include 'Index introduction.'
+  end
+
+  it 'renders see, see-also, formatting, and XML-sensitive terms' do
+    book = to_epub <<~'EOS'
+      = Web
+      :doctype: book
+
+      == Formats
+
+      ((Flash >> HTML 5)) ((HTML 5 &> CSS)) ((CSS)) ((*Tigers*)) ((Cats & kittens)).
+
+      [index]
+      == Index
+    EOS
+
+    index = book.item_by_href('_index.xhtml').content
+
+    expect(index).to include 'Flash, see <a href="#__indextermdef-2">HTML 5</a>'
+    expect(index).to include 'HTML 5, <a href="_formats.xhtml#__indexterm-2">Formats</a>; see also <a href="#__indextermdef-3">CSS</a>'
+    expect(index).to include '<strong>Tigers</strong>'
+    expect(index).to include 'Cats &amp; kittens'
+  end
+
+  it 'links a term in a chapter title to the chapter' do
+    book = to_epub <<~'EOS'
+      = Felines
+      :doctype: book
+
+      == ((Cats))
+
+      [index]
+      == Index
+    EOS
+
+    index = book.item_by_href('_index.xhtml').content
+    expect(index).to include 'href="_cats.xhtml#_cats"'
+  end
+
+  it 'preserves authored content when there are no entries' do
+    book = to_epub <<~'EOS'
+      = Felines
+      :doctype: book
+
+      [index]
+      == Index
+
+      No entries.
+    EOS
+
+    index = book.item_by_href('_index.xhtml').content
+    expect(index).to include 'No entries.'
+    expect(index).not_to include 'index-category'
+  end
+end


### PR DESCRIPTION
Resolves #168.
Depends on asciidoctor/asciidoctor#4872.

This is a draft until the shared index catalog ships with Asciidoctor 2.1 and this project can update its runtime dependency.

## Summary

- consume Asciidoctor's presentation-neutral index catalog instead of duplicating index logic
- generate an index chapter for `[index]` sections
- link every entry to its exact occurrence across chapter files
- support nested and repeated terms, formatted terms, and `see` / `see-also`
- preserve authored index-section content and empty index sections
- use accessible `role=list` markup that renders consistently across Apple Books pagination
- add EPUB styles and focused specs

## Validation

- `RUBYLIB=/Users/dunya.kirkali/Projects/asciidoctor/lib mise exec ruby@3.2.8 java@26.0.0 -- bundle exec rspec` — 100 examples passed
- `mise exec ruby@3.2.8 java@26.0.0 -- bundle exec rubocop` — no offenses
- `mise exec ruby@3.2.8 -- gem build asciidoctor-epub3.gemspec` — passed
- EPUBCheck 5.3.0 on a 5.1 MB real-world book — 0 errors and 0 warnings
- manually verified 19 categories, 74 primary terms, 77 occurrence links, and navigation in Apple Books

The gemspec intentionally remains on `asciidoctor ~> 2.0` for now; it will be bumped once the required API is released.